### PR TITLE
feat(tangle-dapp): Show validator address when avatar is hovered

### DIFF
--- a/apps/tangle-dapp/components/LiquidStaking/LsMyPoolsTable.tsx
+++ b/apps/tangle-dapp/components/LiquidStaking/LsMyPoolsTable.tsx
@@ -35,6 +35,7 @@ import {
 import useLsSetStakingIntent from '../../data/liquidStaking/useLsSetStakingIntent';
 import { useLsStore } from '../../data/liquidStaking/useLsStore';
 import useIsAccountConnected from '../../hooks/useIsAccountConnected';
+import tryEncodeAddressWithPrefix from '../../utils/liquidStaking/tryEncodeAddressWithPrefix';
 import pluralize from '../../utils/pluralize';
 import { TableStatus } from '..';
 import BlueIconButton from '../BlueIconButton';
@@ -99,19 +100,32 @@ const LsMyPoolsTable: FC<LsMyPoolsTableProps> = ({ pools, isShown }) => {
       }),
       COLUMN_HELPER.accessor('ownerAddress', {
         header: () => 'Owner',
-        cell: (props) => (
-          <Tooltip>
-            <TooltipTrigger>
-              <Avatar
-                sourceVariant="address"
-                value={props.getValue()}
-                theme="substrate"
-              />
-            </TooltipTrigger>
+        cell: (props) => {
+          const ownerAddress = props.getValue();
 
-            <TooltipBody className="max-w-none">{props.getValue()}</TooltipBody>
-          </Tooltip>
-        ),
+          if (ownerAddress === undefined) {
+            return EMPTY_VALUE_PLACEHOLDER;
+          }
+
+          return (
+            <Tooltip>
+              <TooltipTrigger>
+                <Avatar
+                  sourceVariant="address"
+                  value={props.getValue()}
+                  theme="substrate"
+                />
+              </TooltipTrigger>
+
+              <TooltipBody className="max-w-none">
+                {tryEncodeAddressWithPrefix(
+                  ownerAddress,
+                  props.row.original.protocolId,
+                )}
+              </TooltipBody>
+            </Tooltip>
+          );
+        },
       }),
       COLUMN_HELPER.accessor('validators', {
         header: () => 'Validators',
@@ -131,7 +145,10 @@ const LsMyPoolsTable: FC<LsMyPoolsTableProps> = ({ pools, isShown }) => {
                   </TooltipTrigger>
 
                   <TooltipBody className="max-w-none">
-                    {substrateAddress}
+                    {tryEncodeAddressWithPrefix(
+                      substrateAddress,
+                      props.row.original.protocolId,
+                    )}
                   </TooltipBody>
                 </Tooltip>
               ))}

--- a/apps/tangle-dapp/components/LiquidStaking/LsMyPoolsTable.tsx
+++ b/apps/tangle-dapp/components/LiquidStaking/LsMyPoolsTable.tsx
@@ -16,6 +16,9 @@ import {
   AvatarGroup,
   Table,
   TANGLE_DOCS_LIQUID_STAKING_URL,
+  Tooltip,
+  TooltipBody,
+  TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
 import { ActionItemType } from '@webb-tools/webb-ui-components/components/ActionsDropdown/types';
@@ -97,11 +100,17 @@ const LsMyPoolsTable: FC<LsMyPoolsTableProps> = ({ pools, isShown }) => {
       COLUMN_HELPER.accessor('ownerAddress', {
         header: () => 'Owner',
         cell: (props) => (
-          <Avatar
-            sourceVariant="address"
-            value={props.row.original.ownerAddress}
-            theme="substrate"
-          />
+          <Tooltip>
+            <TooltipTrigger>
+              <Avatar
+                sourceVariant="address"
+                value={props.getValue()}
+                theme="substrate"
+              />
+            </TooltipTrigger>
+
+            <TooltipBody className="max-w-none">{props.getValue()}</TooltipBody>
+          </Tooltip>
         ),
       }),
       COLUMN_HELPER.accessor('validators', {
@@ -112,14 +121,19 @@ const LsMyPoolsTable: FC<LsMyPoolsTableProps> = ({ pools, isShown }) => {
           ) : (
             <AvatarGroup total={props.row.original.validators.length}>
               {props.row.original.validators.map((substrateAddress) => (
-                <Avatar
-                  key={substrateAddress}
-                  // TODO: In the future, it'd be better if we show the identity of the validator, rather than just the address.
-                  tooltip={substrateAddress}
-                  sourceVariant="address"
-                  value={substrateAddress}
-                  theme="substrate"
-                />
+                <Tooltip key={substrateAddress}>
+                  <TooltipTrigger>
+                    <Avatar
+                      sourceVariant="address"
+                      value={substrateAddress}
+                      theme="substrate"
+                    />
+                  </TooltipTrigger>
+
+                  <TooltipBody className="max-w-none">
+                    {substrateAddress}
+                  </TooltipBody>
+                </Tooltip>
               ))}
             </AvatarGroup>
           ),

--- a/apps/tangle-dapp/containers/LsPoolsTable/LsPoolsTable.tsx
+++ b/apps/tangle-dapp/containers/LsPoolsTable/LsPoolsTable.tsx
@@ -15,6 +15,9 @@ import {
   Button,
   Pagination,
   Table,
+  Tooltip,
+  TooltipBody,
+  TooltipTrigger,
   Typography,
 } from '@webb-tools/webb-ui-components';
 import { FC, useMemo, useState } from 'react';
@@ -74,11 +77,17 @@ const LsPoolsTable: FC<LsPoolsTableProps> = ({ pools, isShown }) => {
     COLUMN_HELPER.accessor('ownerAddress', {
       header: () => 'Owner',
       cell: (props) => (
-        <Avatar
-          sourceVariant="address"
-          value={props.row.original.ownerAddress}
-          theme="substrate"
-        />
+        <Tooltip>
+          <TooltipTrigger>
+            <Avatar
+              sourceVariant="address"
+              value={props.getValue()}
+              theme="substrate"
+            />
+          </TooltipTrigger>
+
+          <TooltipBody className="max-w-none">{props.getValue()}</TooltipBody>
+        </Tooltip>
       ),
     }),
     COLUMN_HELPER.accessor('validators', {
@@ -89,12 +98,19 @@ const LsPoolsTable: FC<LsPoolsTableProps> = ({ pools, isShown }) => {
         ) : (
           <AvatarGroup total={props.row.original.validators.length}>
             {props.row.original.validators.map((substrateAddress) => (
-              <Avatar
-                key={substrateAddress}
-                sourceVariant="address"
-                value={substrateAddress}
-                theme="substrate"
-              />
+              <Tooltip key={substrateAddress}>
+                <TooltipTrigger>
+                  <Avatar
+                    sourceVariant="address"
+                    value={substrateAddress}
+                    theme="substrate"
+                  />
+                </TooltipTrigger>
+
+                <TooltipBody className="max-w-none">
+                  {substrateAddress}
+                </TooltipBody>
+              </Tooltip>
             ))}
           </AvatarGroup>
         ),

--- a/apps/tangle-dapp/containers/LsPoolsTable/LsPoolsTable.tsx
+++ b/apps/tangle-dapp/containers/LsPoolsTable/LsPoolsTable.tsx
@@ -31,6 +31,7 @@ import { EMPTY_VALUE_PLACEHOLDER } from '../../constants';
 import { LsPool, LsPoolDisplayName } from '../../constants/liquidStaking/types';
 import useLsSetStakingIntent from '../../data/liquidStaking/useLsSetStakingIntent';
 import { useLsStore } from '../../data/liquidStaking/useLsStore';
+import tryEncodeAddressWithPrefix from '../../utils/liquidStaking/tryEncodeAddressWithPrefix';
 import pluralize from '../../utils/pluralize';
 
 export type LsPoolsTableProps = {
@@ -76,19 +77,32 @@ const LsPoolsTable: FC<LsPoolsTableProps> = ({ pools, isShown }) => {
     }),
     COLUMN_HELPER.accessor('ownerAddress', {
       header: () => 'Owner',
-      cell: (props) => (
-        <Tooltip>
-          <TooltipTrigger>
-            <Avatar
-              sourceVariant="address"
-              value={props.getValue()}
-              theme="substrate"
-            />
-          </TooltipTrigger>
+      cell: (props) => {
+        const ownerAddress = props.getValue();
 
-          <TooltipBody className="max-w-none">{props.getValue()}</TooltipBody>
-        </Tooltip>
-      ),
+        if (ownerAddress === undefined) {
+          return EMPTY_VALUE_PLACEHOLDER;
+        }
+
+        return (
+          <Tooltip>
+            <TooltipTrigger>
+              <Avatar
+                sourceVariant="address"
+                value={props.getValue()}
+                theme="substrate"
+              />
+            </TooltipTrigger>
+
+            <TooltipBody className="max-w-none">
+              {tryEncodeAddressWithPrefix(
+                ownerAddress,
+                props.row.original.protocolId,
+              )}
+            </TooltipBody>
+          </Tooltip>
+        );
+      },
     }),
     COLUMN_HELPER.accessor('validators', {
       header: () => 'Validators',
@@ -108,7 +122,10 @@ const LsPoolsTable: FC<LsPoolsTableProps> = ({ pools, isShown }) => {
                 </TooltipTrigger>
 
                 <TooltipBody className="max-w-none">
-                  {substrateAddress}
+                  {tryEncodeAddressWithPrefix(
+                    substrateAddress,
+                    props.row.original.protocolId,
+                  )}
                 </TooltipBody>
               </Tooltip>
             ))}

--- a/apps/tangle-dapp/data/liquidStaking/useLsPools.ts
+++ b/apps/tangle-dapp/data/liquidStaking/useLsPools.ts
@@ -1,7 +1,7 @@
 import { BN_ZERO, u8aToString } from '@polkadot/util';
 import { useMemo } from 'react';
 
-import { LsPool, LsProtocolId } from '../../constants/liquidStaking/types';
+import { LsPool } from '../../constants/liquidStaking/types';
 import useNetworkFeatures from '../../hooks/useNetworkFeatures';
 import { NetworkFeature } from '../../types';
 import assertSubstrateAddress from '../../utils/assertSubstrateAddress';
@@ -10,6 +10,7 @@ import useLsPoolCompoundApys from './apy/useLsPoolCompoundApys';
 import useLsBondedPools from './useLsBondedPools';
 import useLsPoolMembers from './useLsPoolMembers';
 import useLsPoolNominations from './useLsPoolNominations';
+import { useLsStore } from './useLsStore';
 
 const useLsPools = (): Map<number, LsPool> | null | Error => {
   const networkFeatures = useNetworkFeatures();
@@ -17,6 +18,7 @@ const useLsPools = (): Map<number, LsPool> | null | Error => {
   const bondedPools = useLsBondedPools();
   const poolMembers = useLsPoolMembers();
   const compoundApys = useLsPoolCompoundApys();
+  const { lsProtocolId } = useLsStore();
 
   const isSupported = networkFeatures.includes(NetworkFeature.LsPools);
 
@@ -84,15 +86,22 @@ const useLsPools = (): Map<number, LsPool> | null | Error => {
         totalStaked,
         apyPercentage,
         members: membersMap,
-        // TODO: Hardcoded for now. Determine the protocol ID.
-        protocolId: LsProtocolId.TANGLE_LOCAL,
+        // TODO: Ensure that this also works for the Restaking Parachain, once it's implemented.
+        protocolId: lsProtocolId,
       };
 
       return [poolId, pool] as const;
     });
 
     return new Map(keyValuePairs);
-  }, [bondedPools, poolNominations, compoundApys, poolMembers, isSupported]);
+  }, [
+    bondedPools,
+    poolNominations,
+    compoundApys,
+    poolMembers,
+    isSupported,
+    lsProtocolId,
+  ]);
 
   // In case that the user connects to testnet or mainnet, but the network
   // doesn't have the liquid staking pools feature.

--- a/apps/tangle-dapp/utils/liquidStaking/tryEncodeAddressWithPrefix.ts
+++ b/apps/tangle-dapp/utils/liquidStaking/tryEncodeAddressWithPrefix.ts
@@ -1,0 +1,19 @@
+import { LsProtocolId } from '../../constants/liquidStaking/types';
+import { SubstrateAddress } from '../../types/utils';
+import { toSubstrateAddress } from '../toSubstrateAddress';
+import getLsProtocolDef from './getLsProtocolDef';
+import getLsTangleNetwork from './getLsTangleNetwork';
+
+const tryEncodeAddressWithPrefix = (
+  address: SubstrateAddress,
+  lsProtocolId: LsProtocolId,
+): SubstrateAddress => {
+  const lsProtocol = getLsProtocolDef(lsProtocolId);
+  const tangleNetwork = getLsTangleNetwork(lsProtocol.networkId);
+
+  return tangleNetwork.ss58Prefix === undefined
+    ? address
+    : toSubstrateAddress(address, tangleNetwork.ss58Prefix);
+};
+
+export default tryEncodeAddressWithPrefix;

--- a/libs/webb-ui-components/src/components/Pagination/Pagination.tsx
+++ b/libs/webb-ui-components/src/components/Pagination/Pagination.tsx
@@ -43,7 +43,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
 
       // If not the last page, return the itemsPerPage
       if (!isLastPage) {
-        return itemsPerPage?.toLocaleString() ?? '-';
+        return itemsPerPage?.toLocaleString() ?? '—';
       }
 
       // Otherwise, calculate the remaining items on the last page
@@ -51,8 +51,10 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
 
       return remainingItems > 0
         ? remainingItems.toLocaleString()
-        : (itemsPerPage?.toLocaleString() ?? '-');
+        : (itemsPerPage?.toLocaleString() ?? '—');
     }, [currentPage, itemsPerPage, totalItems, totalPages]);
+
+    const titleSection = title !== undefined ? `${title} ` : '';
 
     return (
       <div
@@ -68,7 +70,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
         <p className="body1 text-mono-160 dark:text-mono-100">
           {totalItems === 0
             ? 'No items'
-            : `Showing ${showingItemsCount} ${title ?? ''}out of ${totalItems ?? '-'}`}
+            : `Showing ${showingItemsCount} ${titleSection}out of ${totalItems ?? '—'}`}
         </p>
 
         {/** Right buttons */}


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- ➕ On the liquid staking pool tables, when an avatar is hovered, its full address is displayed in a tooltip. This helps users recognize validators.
- 🐛 Fixed a small bug related to a missing space in the Pagination component's title.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/webb-ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2639

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

![Screenshot 2024-11-08 at 20 14 19](https://github.com/user-attachments/assets/179724a8-3083-479b-b324-01e6a4070e9d)
