### PR TITLE
feat(tangle-dapp): Add `Join Operator` button & modal

### DIFF
--- a/apps/tangle-dapp/src/components/BlueIconButton.tsx
+++ b/apps/tangle-dapp/src/components/BlueIconButton.tsx
@@ -36,9 +36,7 @@ const BlueIconButton: FC<BlueIconButtonProps> = ({
         </IconButton>
       </TooltipTrigger>
 
-      <TooltipBody className="break-normal max-w-[250px] text-center">
-        {tooltip}
-      </TooltipBody>
+      <TooltipBody>{tooltip}</TooltipBody>
     </Tooltip>
   );
 };

--- a/apps/tangle-dapp/src/components/account/ActionItem.tsx
+++ b/apps/tangle-dapp/src/components/account/ActionItem.tsx
@@ -88,9 +88,7 @@ const ActionItem: FC<ActionItemProps> = ({
 
   return tooltip !== undefined ? (
     <Tooltip>
-      <TooltipBody className="break-normal max-w-[250px] text-center">
-        {tooltip}
-      </TooltipBody>
+      <TooltipBody>{tooltip}</TooltipBody>
 
       <TooltipTrigger asChild>{withLink}</TooltipTrigger>
     </Tooltip>

--- a/apps/tangle-dapp/src/constants/index.ts
+++ b/apps/tangle-dapp/src/constants/index.ts
@@ -1,4 +1,3 @@
-import { SubstrateAddress } from '@webb-tools/webb-ui-components/types/address';
 import {
   StakingRewardsDestination,
   StakingRewardsDestinationDisplayText,
@@ -66,6 +65,7 @@ export enum TxName {
   LS_TANGLE_POOL_UNBOND = 'unstake from liquid staking pool',
   LS_TANGLE_POOL_CREATE = 'create liquid staking pool',
   LS_TANGLE_POOL_UPDATE_ROLES = 'update pool roles',
+  RESTAKE_JOIN_OPERATORS = 'join operators',
 }
 
 export const PAYMENT_DESTINATION_OPTIONS: StakingRewardsDestinationDisplayText[] =

--- a/apps/tangle-dapp/src/containers/BalancesTableContainer/BalanceAction.tsx
+++ b/apps/tangle-dapp/src/containers/BalancesTableContainer/BalanceAction.tsx
@@ -50,9 +50,7 @@ const BalanceAction: FC<{
     <Tooltip>
       <TooltipTrigger asChild>{trigger}</TooltipTrigger>
 
-      <TooltipBody className="break-normal max-w-[250px] text-center">
-        {tooltip}
-      </TooltipBody>
+      <TooltipBody>{tooltip}</TooltipBody>
     </Tooltip>
   );
 };

--- a/apps/tangle-dapp/src/containers/BalancesTableContainer/BalanceCell.tsx
+++ b/apps/tangle-dapp/src/containers/BalancesTableContainer/BalanceCell.tsx
@@ -50,9 +50,7 @@ const BalanceCell: FC<{
             <StatusIndicator size={12} variant="info" />
           </TooltipTrigger>
 
-          <TooltipBody className="break-normal max-w-[250px] text-center">
-            {status}
-          </TooltipBody>
+          <TooltipBody>{status}</TooltipBody>
         </Tooltip>
       )}
     </div>

--- a/apps/tangle-dapp/src/containers/BalancesTableContainer/LockedBalanceDetails/TextCell.tsx
+++ b/apps/tangle-dapp/src/containers/BalancesTableContainer/LockedBalanceDetails/TextCell.tsx
@@ -30,9 +30,7 @@ const TextCell: FC<{
             <StatusIndicator size={12} variant={statusVariant} />
           </TooltipTrigger>
 
-          <TooltipBody className="break-normal max-w-[250px] text-center">
-            {status}
-          </TooltipBody>
+          <TooltipBody>{status}</TooltipBody>
         </Tooltip>
       )}
     </div>

--- a/apps/tangle-dapp/src/containers/PayoutTxContainer/PayoutTxContainer.tsx
+++ b/apps/tangle-dapp/src/containers/PayoutTxContainer/PayoutTxContainer.tsx
@@ -103,17 +103,17 @@ const PayoutTxContainer: FC<PayoutTxContainerProps> = ({
           </div>
 
           <div className="flex flex-col gap-9">
-            <Typography variant="body1" fw="normal">
+            <Typography variant="body1">
               Any account can request payout for stakers, this is not limited to
               accounts that will be rewarded.
             </Typography>
 
-            <Typography variant="body1" fw="normal">
+            <Typography variant="body1">
               All the listed validators and all their nominators will receive
               their rewards.
             </Typography>
 
-            <Typography variant="body1" fw="normal">
+            <Typography variant="body1">
               The UI puts a limit of {MAX_PAYOUTS_BATCH_SIZE} payouts at a time,
               where each payout is a single validator for a single era.
             </Typography>

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
@@ -1,0 +1,38 @@
+import { ArrowRight } from '@webb-tools/icons';
+import RestakeBanner from '@webb-tools/tangle-shared-ui/components/blueprints/RestakeBanner';
+import { Button } from '@webb-tools/webb-ui-components';
+import { OPERATOR_JOIN_DOCS_LINK } from '@webb-tools/webb-ui-components/constants/tangleDocs';
+import { FC, useState } from 'react';
+import JoinOperatorsModal from './JoinOperatorsModal';
+
+const JoinOperatorsBanner: FC = () => {
+  const [isJoinOperatorsModalOpen, setIsJoinOperatorsModalOpen] =
+    useState(false);
+
+  return (
+    <>
+      <RestakeBanner
+        title="Register as an Operator"
+        description="Interested in becoming an operator? Operators host blueprints and earn rewards for their delegators. Register as an operator to get started."
+        buttonText="Learn More"
+        buttonHref={OPERATOR_JOIN_DOCS_LINK}
+        action={
+          <Button
+            variant="primary"
+            rightIcon={<ArrowRight />}
+            onClick={() => setIsJoinOperatorsModalOpen(true)}
+          >
+            Join Operators
+          </Button>
+        }
+      />
+
+      <JoinOperatorsModal
+        isOpen={isJoinOperatorsModalOpen}
+        setIsOpen={setIsJoinOperatorsModalOpen}
+      />
+    </>
+  );
+};
+
+export default JoinOperatorsBanner;

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
@@ -27,6 +27,7 @@ const JoinOperatorsBanner: FC = () => {
         buttonHref={OPERATOR_JOIN_DOCS_LINK}
         action={
           <Button
+            className="w-full max-w-none sm:max-w-max sm:w-auto"
             variant="primary"
             rightIcon={
               <ArrowRight

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
@@ -5,26 +5,37 @@ import { OPERATOR_JOIN_DOCS_LINK } from '@webb-tools/webb-ui-components/constant
 import { FC, useState } from 'react';
 import JoinOperatorsModal from './JoinOperatorsModal';
 import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
+import useIsAccountConnected from '../../hooks/useIsAccountConnected';
 
 const JoinOperatorsBanner: FC = () => {
   const [isJoinOperatorsModalOpen, setIsJoinOperatorsModalOpen] =
     useState(false);
 
   const { isEvm } = useAgnosticAccountInfo();
+  const isAccountConnected = useIsAccountConnected();
+
+  const disabledTooltip = isAccountConnected
+    ? 'Only Substrate accounts can register as operators at this time.'
+    : 'Connect a Substrate account to join as an operator.';
 
   return (
     <>
       <RestakeBanner
         title="Register as an Operator"
-        description="Interested in becoming an operator? Operators host blueprints and earn rewards for their delegators. Register as an operator to get started."
+        description="With Tangle, operators and their delegators get rewarded by hosting blueprints. Interested in becoming an operator? Bond some tokens to get started."
         buttonText="Learn More"
         buttonHref={OPERATOR_JOIN_DOCS_LINK}
         action={
           <Button
             variant="primary"
-            rightIcon={<ArrowRight />}
+            rightIcon={
+              <ArrowRight
+                size="lg"
+                className="fill-current dark:fill-current"
+              />
+            }
             onClick={() => setIsJoinOperatorsModalOpen(true)}
-            disabledTooltip="Only Substrate accounts can register as operators at this time."
+            disabledTooltip={disabledTooltip}
             // Disable the button until it is known whether the current account
             // is an EVM account or not.
             isDisabled={isEvm ?? true}

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsBanner.tsx
@@ -4,10 +4,13 @@ import { Button } from '@webb-tools/webb-ui-components';
 import { OPERATOR_JOIN_DOCS_LINK } from '@webb-tools/webb-ui-components/constants/tangleDocs';
 import { FC, useState } from 'react';
 import JoinOperatorsModal from './JoinOperatorsModal';
+import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
 
 const JoinOperatorsBanner: FC = () => {
   const [isJoinOperatorsModalOpen, setIsJoinOperatorsModalOpen] =
     useState(false);
+
+  const { isEvm } = useAgnosticAccountInfo();
 
   return (
     <>
@@ -21,6 +24,10 @@ const JoinOperatorsBanner: FC = () => {
             variant="primary"
             rightIcon={<ArrowRight />}
             onClick={() => setIsJoinOperatorsModalOpen(true)}
+            disabledTooltip="Only Substrate accounts can register as operators at this time."
+            // Disable the button until it is known whether the current account
+            // is an EVM account or not.
+            isDisabled={isEvm ?? true}
           >
             Join Operators
           </Button>

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsModal.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsModal.tsx
@@ -84,6 +84,7 @@ const JoinOperatorsModal: FC<Props> = ({ isOpen, setIsOpen }) => {
             setAmount={setBondAmount}
             placeholder="Enter the amount to bond"
             setErrorMessage={setErrorMessage}
+            wrapperOverrides={{ isFullWidth: true }}
           />
 
           <Caption linkHref={OPERATOR_JOIN_DOCS_LINK}>{captionText}</Caption>

--- a/apps/tangle-dapp/src/containers/restaking/JoinOperatorsModal.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/JoinOperatorsModal.tsx
@@ -1,0 +1,103 @@
+import {
+  AmountFormatStyle,
+  Caption,
+  formatDisplayAmount,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooterActions,
+  ModalHeader,
+} from '@webb-tools/webb-ui-components';
+import { FC, useCallback, useMemo, useState } from 'react';
+import useJoinOperatorsTx from '../../data/restake/useJoinOperatorsTx';
+import { TxStatus } from '../../hooks/useSubstrateTx';
+import AmountInput from '../../components/AmountInput';
+import { BN } from '@polkadot/util';
+import useApi from '../../hooks/useApi';
+import useNetworkStore from '@webb-tools/tangle-shared-ui/context/useNetworkStore';
+import { TANGLE_TOKEN_DECIMALS } from '@webb-tools/dapp-config';
+import { OPERATOR_JOIN_DOCS_LINK } from '@webb-tools/webb-ui-components/constants/tangleDocs';
+import useBalances from '../../data/balances/useBalances';
+
+type Props = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+const JoinOperatorsModal: FC<Props> = ({ isOpen, setIsOpen }) => {
+  const [bondAmount, setBondAmount] = useState<BN | null>(null);
+  const { nativeTokenSymbol } = useNetworkStore();
+  const { execute, status } = useJoinOperatorsTx();
+  const { free } = useBalances();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isReady =
+    status !== TxStatus.PROCESSING &&
+    bondAmount !== null &&
+    execute !== null &&
+    errorMessage === null;
+
+  const handleConfirmClick = useCallback(() => {
+    if (!isReady) {
+      return;
+    }
+
+    return execute({ bondAmount });
+  }, [bondAmount, execute, isReady]);
+
+  const { result: minOperatorBond } = useApi(
+    useCallback(
+      (api) => api.consts.multiAssetDelegation.minOperatorBondAmount.toBn(),
+      [],
+    ),
+  );
+
+  const captionText = useMemo<string>(() => {
+    if (minOperatorBond === null) {
+      return 'A minimum bond amount may be required to register as an operator. This stake recovered after an unbonding period.';
+    }
+
+    const fmtMinOperatorBond = formatDisplayAmount(
+      minOperatorBond,
+      TANGLE_TOKEN_DECIMALS,
+      AmountFormatStyle.EXACT,
+    );
+
+    return `A minimum bond amount of ${fmtMinOperatorBond} ${nativeTokenSymbol} is required to register as an operator. This stake recovered after an unbonding period.`;
+  }, [minOperatorBond, nativeTokenSymbol]);
+
+  return (
+    <Modal open={isOpen} onOpenChange={setIsOpen}>
+      <ModalContent size="sm">
+        <ModalHeader onClose={() => setIsOpen(false)}>
+          Join Operators
+        </ModalHeader>
+
+        <ModalBody className="gap-3">
+          <AmountInput
+            id="restake-join-operators-bond"
+            title="Bond Amount"
+            amount={bondAmount}
+            min={minOperatorBond}
+            max={free}
+            showMaxAction
+            setAmount={setBondAmount}
+            placeholder="Enter the amount to bond"
+            setErrorMessage={setErrorMessage}
+          />
+
+          <Caption linkHref={OPERATOR_JOIN_DOCS_LINK}>{captionText}</Caption>
+        </ModalBody>
+
+        <ModalFooterActions
+          onClose={() => setIsOpen(false)}
+          isProcessing={status === TxStatus.PROCESSING}
+          onConfirm={handleConfirmClick}
+          isConfirmDisabled={!isReady}
+        />
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default JoinOperatorsModal;

--- a/apps/tangle-dapp/src/data/restake/useJoinOperatorsTx.ts
+++ b/apps/tangle-dapp/src/data/restake/useJoinOperatorsTx.ts
@@ -1,0 +1,19 @@
+import { useCallback } from 'react';
+import { TxName } from '../../constants';
+import { useSubstrateTxWithNotification } from '../../hooks/useSubstrateTx';
+import { BN } from '@polkadot/util';
+
+type Context = {
+  bondAmount: BN;
+};
+
+const useJoinOperatorsTx = () => {
+  return useSubstrateTxWithNotification<Context>(
+    TxName.RESTAKE_JOIN_OPERATORS,
+    useCallback((api, _activeSubstrateAddress, context) => {
+      return api.tx.multiAssetDelegation.joinOperators(context.bondAmount);
+    }, []),
+  );
+};
+
+export default useJoinOperatorsTx;

--- a/apps/tangle-dapp/src/hooks/useInputAmount.ts
+++ b/apps/tangle-dapp/src/hooks/useInputAmount.ts
@@ -11,6 +11,7 @@ import cleanNumericInputString from '../utils/cleanNumericInputString';
 import parseChainUnits, {
   ChainUnitParsingError,
 } from '../utils/parseChainUnits';
+import pluralize from '@webb-tools/webb-ui-components/utils/pluralize';
 
 type SafeParseInputAmountOptions = {
   amountString: string;
@@ -32,15 +33,15 @@ function safeParseInputAmount(
       case ChainUnitParsingError.EmptyAmount:
         return options.errorOnEmptyValue ? 'Amount is required' : null;
       case ChainUnitParsingError.ExceedsDecimals:
-        return `Amount cannot exceed ${options.decimals} decimal places`;
+        return `Precision cannot exceed ${options.decimals} decimal ${pluralize('place', options.decimals !== 1)}`;
     }
   } else if (options.min !== null && result.lt(options.min)) {
     return (
       options.minErrorMessage ??
-      `Min amount required ${formatDisplayAmount(
+      `Minimum amount required is ${formatDisplayAmount(
         options.min,
         options.decimals,
-        AmountFormatStyle.SHORT,
+        AmountFormatStyle.EXACT,
       )}`
     );
   } else if (options.max !== null && result.gt(options.max)) {
@@ -49,7 +50,7 @@ function safeParseInputAmount(
       `Max amount allowed is ${formatDisplayAmount(
         options.max,
         options.decimals,
-        AmountFormatStyle.SHORT,
+        AmountFormatStyle.EXACT,
       )}`
     );
   }

--- a/apps/tangle-dapp/src/hooks/useTxNotification.tsx
+++ b/apps/tangle-dapp/src/hooks/useTxNotification.tsx
@@ -39,6 +39,7 @@ const SUCCESS_MESSAGES: Record<TxName, string> = {
   [TxName.LS_TANGLE_POOL_UNBOND]: 'Unbonded from liquid staking pool',
   [TxName.LS_TANGLE_POOL_CREATE]: 'Created liquid staking pool',
   [TxName.LS_TANGLE_POOL_UPDATE_ROLES]: 'Updated pool roles',
+  [TxName.RESTAKE_JOIN_OPERATORS]: 'Joined as an operator',
 };
 
 const makeKey = (txName: TxName): `${TxName}-tx-notification` =>

--- a/apps/tangle-dapp/src/pages/restake/overview/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/overview/index.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 import { RestakeAction } from '../../../constants';
 import NotFoundPage from '../../notFound';
 import isEnumValue from '../../../utils/isEnumValue';
+import JoinOperatorsBanner from '../../../containers/restaking/JoinOperatorsBanner';
 
 export default function RestakePage() {
   const { action } = useParams();
@@ -21,14 +22,18 @@ export default function RestakePage() {
   }
 
   return (
-    <RestakeOverviewTabs
-      delegatorTVL={delegatorTVL}
-      operatorMap={operatorMap}
-      delegatorInfo={delegatorInfo}
-      operatorTVL={operatorTVL}
-      vaultTVL={vaultTVL}
-      operatorConcentration={operatorConcentration}
-      action={action ?? RestakeAction.DEPOSIT}
-    />
+    <div className="space-y-7">
+      <JoinOperatorsBanner />
+
+      <RestakeOverviewTabs
+        delegatorTVL={delegatorTVL}
+        operatorMap={operatorMap}
+        delegatorInfo={delegatorInfo}
+        operatorTVL={operatorTVL}
+        vaultTVL={vaultTVL}
+        operatorConcentration={operatorConcentration}
+        action={action ?? RestakeAction.DEPOSIT}
+      />
+    </div>
   );
 }

--- a/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
+++ b/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
@@ -23,7 +23,7 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
   return (
     <div
       className={twMerge(
-        'flex justify-between items-center gap-3 px-6 py-9 rounded-xl bg-center bg-cover bg-no-repeat bg-top-banner',
+        'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-6 sm:gap-9 px-6 py-9 rounded-xl bg-center bg-cover bg-no-repeat bg-top-banner',
       )}
     >
       <div className="max-w-[600px] space-y-4">
@@ -41,6 +41,7 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
         </div>
 
         <Button
+          className="hidden sm:flex"
           variant="link"
           href={buttonHref}
           target="_blank"

--- a/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
+++ b/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
@@ -1,7 +1,7 @@
-import { ArrowRight } from '@webb-tools/icons';
+import { ArrowRightUp } from '@webb-tools/icons';
 import Button from '@webb-tools/webb-ui-components/components/buttons/Button';
 import { Typography } from '@webb-tools/webb-ui-components/typography/Typography';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 import './top-banner.css';
 
@@ -10,6 +10,7 @@ export type RestakeBannerProps = {
   description: string;
   buttonText: string;
   buttonHref: string;
+  action?: ReactNode;
 };
 
 const RestakeBanner: FC<RestakeBannerProps> = ({
@@ -17,14 +18,15 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
   description,
   buttonText,
   buttonHref,
+  action,
 }) => {
   return (
     <div
       className={twMerge(
-        'px-6 py-9 rounded-xl bg-center bg-cover bg-no-repeat bg-top-banner',
+        'flex justify-between items-center gap-3 px-6 py-9 rounded-xl bg-center bg-cover bg-no-repeat bg-top-banner',
       )}
     >
-      <div className="max-w-[500px] space-y-6">
+      <div className="max-w-[600px] space-y-4">
         <div className="space-y-3">
           <Typography variant="h4" className="text-mono-0">
             {title}
@@ -43,12 +45,17 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
           href={buttonHref}
           target="_blank"
           rightIcon={
-            <ArrowRight size="lg" className="fill-current dark:fill-current" />
+            <ArrowRightUp
+              size="lg"
+              className="fill-current dark:fill-current"
+            />
           }
         >
           {buttonText}
         </Button>
       </div>
+
+      {action}
     </div>
   );
 };

--- a/libs/webb-ui-components/src/components/Avatar/Avatar.tsx
+++ b/libs/webb-ui-components/src/components/Avatar/Avatar.tsx
@@ -110,9 +110,7 @@ export const Avatar: React.FC<AvatarProps> = ({
     <Tooltip>
       <TooltipTrigger>{avatar}</TooltipTrigger>
 
-      <TooltipBody className="break-normal max-w-[250px] text-center">
-        {tooltip}
-      </TooltipBody>
+      <TooltipBody>{tooltip}</TooltipBody>
     </Tooltip>
   ) : (
     avatar

--- a/libs/webb-ui-components/src/components/BridgeInputs/InfoItem.tsx
+++ b/libs/webb-ui-components/src/components/BridgeInputs/InfoItem.tsx
@@ -3,6 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import { Typography } from '../../typography/Typography';
 import { TitleWithInfo } from '../TitleWithInfo';
 import { InfoItemProps } from './types';
+import { EMPTY_VALUE_PLACEHOLDER } from '../../constants';
 
 /**
  * The `InfoItem` component
@@ -49,7 +50,7 @@ export const InfoItem = forwardRef<HTMLDivElement, InfoItemProps>(
             fw="bold"
             className="text-mono-180 dark:text-mono-80"
           >
-            --
+            {EMPTY_VALUE_PLACEHOLDER}
           </Typography>
         ) : typeof rightContent === 'string' ? (
           <Typography

--- a/libs/webb-ui-components/src/components/Caption.tsx
+++ b/libs/webb-ui-components/src/components/Caption.tsx
@@ -1,14 +1,34 @@
 import { FC } from 'react';
 import { Typography } from '../typography';
+import { ArrowRightUp } from '@webb-tools/icons';
 
 export type CaptionProps = {
   children: string | string[];
+  linkText?: string;
+  linkHref?: string;
 };
 
-export const Caption: FC<CaptionProps> = ({ children }) => {
+export const Caption: FC<CaptionProps> = ({
+  children,
+  linkText = 'Learn More',
+  linkHref,
+}) => {
   return (
     <Typography variant="body2" className="pl-2 dark:text-mono-100">
-      {children}
+      {children}{' '}
+      {linkHref !== undefined && (
+        // TODO: Replace with `ExternalLink` component for consistency (it requires some tinkering to make it inline correctly).
+        <a
+          className="text-blue-50 dark:text-blue-50 whitespace-nowrap"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={linkHref}
+        >
+          {linkText}
+
+          <ArrowRightUp className="inline fill-blue-50 dark:fill-blue-50" />
+        </a>
+      )}
     </Typography>
   );
 };

--- a/libs/webb-ui-components/src/components/CheckBox/Checkbox.tsx
+++ b/libs/webb-ui-components/src/components/CheckBox/Checkbox.tsx
@@ -123,7 +123,7 @@ export const CheckBox: FC<CheckBoxProps> = (props) => {
 
           <TooltipBody
             title={info.title}
-            className="max-w-[185px] break-normal"
+            className="max-w-[185px]"
             button={
               info.buttonProps && (
                 <Button {...info.buttonProps} variant="utility" size="sm">

--- a/libs/webb-ui-components/src/components/CircularProgress.tsx
+++ b/libs/webb-ui-components/src/components/CircularProgress.tsx
@@ -56,9 +56,7 @@ export const CircularProgress: FC<CircularProgressProps> = ({
     <Tooltip>
       <TooltipTrigger>{progressComponent}</TooltipTrigger>
 
-      <TooltipBody className="break-normal max-w-[250px] text-center">
-        {tooltip}
-      </TooltipBody>
+      <TooltipBody>{tooltip}</TooltipBody>
     </Tooltip>
   );
 };

--- a/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
+++ b/libs/webb-ui-components/src/components/IconWithTooltip/IconWithTooltip.tsx
@@ -1,7 +1,6 @@
 import { type FC } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import { Typography } from '../../typography/Typography';
 import { Tooltip, TooltipBody, TooltipTrigger } from '../Tooltip/Tooltip';
 import { IconWithTooltipProp } from './types';
 
@@ -24,11 +23,7 @@ const IconWithTooltip: FC<IconWithTooltipProp> = ({
         {icon}
       </TooltipTrigger>
 
-      <TooltipBody {...overrideTooltipBodyProps}>
-        <Typography variant="body2" className="text-center break-normal">
-          {content}
-        </Typography>
-      </TooltipBody>
+      <TooltipBody {...overrideTooltipBodyProps}>{content}</TooltipBody>
     </Tooltip>
   );
 };

--- a/libs/webb-ui-components/src/components/ListCard/TokenListItem.tsx
+++ b/libs/webb-ui-components/src/components/ListCard/TokenListItem.tsx
@@ -17,6 +17,7 @@ import SkeletonLoader from '../SkeletonLoader';
 import { Button } from '../buttons';
 import { ListItem } from './ListItem';
 import { AssetBadgeInfoType, AssetBalanceType, AssetType } from './types';
+import { EMPTY_VALUE_PLACEHOLDER } from '../../constants';
 
 const Balance = ({ balance, balanceInUsd, subContent }: AssetBalanceType) => {
   return (
@@ -62,12 +63,13 @@ const AddToWalletButton = ({
     >
       Add to Wallet
     </Button>
+
     <Typography
       className="block cursor-default group-hover:hidden"
       variant="h5"
       fw="bold"
     >
-      --
+      {EMPTY_VALUE_PLACEHOLDER}
     </Typography>
   </>
 );

--- a/libs/webb-ui-components/src/components/Modal/ModalFooterActions.tsx
+++ b/libs/webb-ui-components/src/components/Modal/ModalFooterActions.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import { ModalFooter } from './ModalFooter';
 import { Button } from '../buttons';
-import useIsBreakpoint from '../../hooks/useIsBreakpoint';
 
 export type ModalFooterActionsProps = {
   isConfirmDisabled?: boolean;
@@ -20,15 +19,9 @@ export const ModalFooterActions: FC<ModalFooterActionsProps> = ({
   onConfirm,
   onClose,
 }) => {
-  const isMobile = useIsBreakpoint('md', true);
-
   return (
     <ModalFooter>
-      {/**
-       * Remove the secondary button on mobile viewports due to
-       * limited space.
-       */}
-      {learnMoreLinkHref !== undefined && !isMobile ? (
+      {learnMoreLinkHref !== undefined ? (
         <Button
           isFullWidth
           variant="secondary"
@@ -36,6 +29,7 @@ export const ModalFooterActions: FC<ModalFooterActionsProps> = ({
           rel="noopener noreferrer"
           href={learnMoreLinkHref}
           isDisabled={isProcessing}
+          className="hidden sm:flex"
         >
           Learn More
         </Button>
@@ -46,6 +40,7 @@ export const ModalFooterActions: FC<ModalFooterActionsProps> = ({
             variant="secondary"
             isDisabled={isProcessing}
             onClick={onClose}
+            className="hidden sm:flex"
           >
             Cancel
           </Button>

--- a/libs/webb-ui-components/src/components/TitleWithInfo/TitleWithInfo.tsx
+++ b/libs/webb-ui-components/src/components/TitleWithInfo/TitleWithInfo.tsx
@@ -54,7 +54,8 @@ export const TitleWithInfo = forwardRef<HTMLDivElement, TitleWithInfoProps>(
                 <InformationLine className="!fill-current pointer-events-none" />
               </span>
             </TooltipTrigger>
-            <TooltipBody className="break-normal max-w-[200px]">
+
+            <TooltipBody className="max-w-[200px]">
               {isPrimitive(info) && info !== null && info !== undefined ? (
                 <Typography
                   ta={isCenterInfo ? 'center' : 'left'}

--- a/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
+++ b/libs/webb-ui-components/src/components/TokenPairIcons/TokenPairIcons.tsx
@@ -20,6 +20,7 @@ export const TokenPairIcons = forwardRef<HTMLDivElement, TokenPairIconsProps>(
           icon={<TokenIcon size="lg" name={token1Symbol.toLowerCase()} />}
           content={token1Symbol}
         />
+
         <IconWithTooltip
           icon={<TokenIcon size="lg" name={token2Symbol.toLowerCase()} />}
           content={token2Symbol}

--- a/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
+++ b/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
@@ -44,7 +44,7 @@ export const TooltipBody: React.FC<TooltipBodyProps> = ({
     >
       <div
         className={twMerge(
-          'body4 text-mono-140 dark:text-mono-80 font-normal min-w-0 max-w-[300px]',
+          'body2 text-mono-140 dark:text-mono-80 text-center break-normal font-normal min-w-0 max-w-[300px]',
           className,
         )}
       >

--- a/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
+++ b/libs/webb-ui-components/src/components/Tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ import { TooltipBodyProps, TooltipProps, TooltipTriggerProps } from './types';
 
 /**
  * The `ToolTipBody` component, use after the `TooltipTrigger`.
- * Reresents the popup content of the tooltip.
+ * Represents the popup content of the tooltip.
  * Must use inside the `Tooltip` component.
  *
  * @example
@@ -44,7 +44,7 @@ export const TooltipBody: React.FC<TooltipBodyProps> = ({
     >
       <div
         className={twMerge(
-          'body2 text-mono-140 dark:text-mono-80 text-center break-normal font-normal min-w-0 max-w-[300px]',
+          'body2 text-mono-140 dark:text-mono-80 text-center break-normal font-normal min-w-0 max-w-[250px]',
           className,
         )}
       >

--- a/libs/webb-ui-components/src/components/buttons/Button.tsx
+++ b/libs/webb-ui-components/src/components/buttons/Button.tsx
@@ -8,6 +8,7 @@ import { ButtonContentProps, ButtonProps } from './types';
 import { useButtonProps } from './use-button-props';
 import { getButtonClassNameByVariant } from './utils';
 import { forwardRef } from 'react';
+import { Tooltip, TooltipBody, TooltipTrigger } from '../Tooltip';
 
 /**
  * The Webb Button Component
@@ -48,6 +49,7 @@ const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
     spinnerPlacement = 'start',
     variant = 'primary',
     isJustIcon,
+    disabledTooltip,
     ...restProps
   } = props;
 
@@ -67,7 +69,7 @@ const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
 
   const contentProps = { children, leftIcon, rightIcon, variant };
 
-  return (
+  const button = (
     <Component
       {...restProps}
       {...buttonProps}
@@ -93,6 +95,18 @@ const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
         </ButtonSpinner>
       )}
     </Component>
+  );
+
+  if (disabledTooltip === undefined) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>{button}</TooltipTrigger>
+
+      <TooltipBody>{disabledTooltip}</TooltipBody>
+    </Tooltip>
   );
 });
 

--- a/libs/webb-ui-components/src/components/buttons/Button.tsx
+++ b/libs/webb-ui-components/src/components/buttons/Button.tsx
@@ -97,6 +97,8 @@ const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
     </Component>
   );
 
+  // If the button isn't disabled or a tooltip for the disabled state isn't
+  // provided, just return the button as is.
   if (disabledTooltip === undefined || !isDisabled) {
     return button;
   }

--- a/libs/webb-ui-components/src/components/buttons/Button.tsx
+++ b/libs/webb-ui-components/src/components/buttons/Button.tsx
@@ -97,7 +97,7 @@ const Button = forwardRef<HTMLElement, ButtonProps>((props, ref) => {
     </Component>
   );
 
-  if (disabledTooltip === undefined) {
+  if (disabledTooltip === undefined || !isDisabled) {
     return button;
   }
 

--- a/libs/webb-ui-components/src/components/buttons/types.ts
+++ b/libs/webb-ui-components/src/components/buttons/types.ts
@@ -141,6 +141,13 @@ export interface ButtonProps extends ButtonBase, IWebbComponentBase {
    * If `true`, the size of the button will be adjusted to fit the icon based on the variant
    */
   isJustIcon?: boolean;
+
+  /**
+   * A tooltip to display when the button is disabled.
+   *
+   * Useful for explaining why the button is disabled.
+   */
+  disabledTooltip?: string;
 }
 
 export interface ButtonSpinnerProps extends WebbComponentBase {

--- a/libs/webb-ui-components/src/containers/ConfirmationCard/AmountInfo.tsx
+++ b/libs/webb-ui-components/src/containers/ConfirmationCard/AmountInfo.tsx
@@ -6,6 +6,7 @@ import {
   FileShieldLine,
   InformationLine,
 } from '@webb-tools/icons';
+import { EMPTY_VALUE_PLACEHOLDER } from '../../constants';
 
 interface AmountInfoProps {
   label: string;
@@ -47,12 +48,13 @@ const AmountInfo: FC<AmountInfoProps> = ({
           />
         )}
       </div>
+
       <Typography
         variant="body1"
         fw="bold"
         className="text-mono-190 dark:text-mono-40"
       >
-        {amount ?? '--'} {tokenSymbol}
+        {amount ?? EMPTY_VALUE_PLACEHOLDER} {tokenSymbol}
       </Typography>
     </div>
   );

--- a/libs/webb-ui-components/src/containers/ConfirmationCard/RefundAmount.tsx
+++ b/libs/webb-ui-components/src/containers/ConfirmationCard/RefundAmount.tsx
@@ -8,6 +8,7 @@ import {
 import { CopyWithTooltip } from '../../components/CopyWithTooltip/CopyWithTooltip';
 import { IconWithTooltip } from '../../components/IconWithTooltip';
 import { Typography } from '../../typography';
+import { EMPTY_VALUE_PLACEHOLDER } from '../../constants';
 
 interface RefundAmountProps {
   amount?: number | string;
@@ -64,7 +65,7 @@ const RefundAmount: FC<RefundAmountProps> = ({
           fw="bold"
           className="text-mono-190 dark:text-mono-40"
         >
-          {amount ?? '--'} {tokenSymbol}
+          {amount ?? EMPTY_VALUE_PLACEHOLDER} {tokenSymbol}
         </Typography>
 
         <IconWithTooltip


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- ➕ Added the `Join Operator` banner, button and modal, as well as the transaction logic.
- ➕ Added a prop for the `Button` component which allows a tooltip to be displayed when it is disabled.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/webb-ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2741

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

banner & button:
![Screenshot 2025-01-15 at 15 19 15](https://github.com/user-attachments/assets/d247796d-edcb-4728-8fe4-486d6b045985)
modal:
![Screenshot 2025-01-15 at 15 19 46](https://github.com/user-attachments/assets/d509ea58-8163-4729-bf51-c8e4bc97a8a9)
when an evm account is connected:
![Screenshot 2025-01-15 at 15 27 49](https://github.com/user-attachments/assets/b797a34b-7012-405c-89a4-8c1fc2ffc8ad)
mobile viewport:
![Screenshot 2025-01-15 at 16 01 57](https://github.com/user-attachments/assets/8a1a30b3-879a-410c-b3cc-f3537630606a)
mobile viewport modal:
![Screenshot 2025-01-15 at 16 02 13](https://github.com/user-attachments/assets/979c758c-d62e-453a-9c10-da021c4cdec7)
