### PR TITLE
fix(tangle-dapp): Improve Error Handling When Parsing Response

### DIFF
--- a/apps/tangle-dapp/src/components/KeyStatsItem/KeyStatsItem.tsx
+++ b/apps/tangle-dapp/src/components/KeyStatsItem/KeyStatsItem.tsx
@@ -16,6 +16,7 @@ export type KeyStatsItemProps = {
   tooltip?: string;
   className?: string;
   showDataBeforeLoading?: boolean;
+  hideErrorNotification?: boolean;
   children?: ReactNode;
   error: Error | null;
   isLoading?: boolean;
@@ -27,6 +28,7 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
   tooltip,
   className,
   showDataBeforeLoading,
+  hideErrorNotification = false,
   prefix,
   suffix,
   children,
@@ -36,13 +38,13 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
   // If present, report errors to the user via a toast
   // notification.
   useEffect(() => {
-    if (error !== null) {
+    if (error !== null && !hideErrorNotification) {
       notificationApi({
         variant: 'error',
         message: error.message,
       });
     }
-  }, [error]);
+  }, [error, hideErrorNotification]);
 
   return (
     <div

--- a/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
+++ b/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
@@ -46,6 +46,7 @@ const RewardsAndPoints = () => {
   return (
     <div className="grid grid-cols-2 gap-6">
       <KeyStatsItem
+        hideErrorNotification
         isLoading={isLoading}
         className="!p-0"
         title="Unclaimed Rewards"


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Add an option to disable error notifications for the KeyStatsItem component.
- Do not throw an error when fetching rewards.
- Avoid retrying on errors when fetching rewards.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/webb-ui-components`