### PR TITLE
fix(tangle-shared-ui): Fix Talisman Keep Popping Up

### DIFF
--- a/libs/dapp-config/src/types.ts
+++ b/libs/dapp-config/src/types.ts
@@ -1,4 +1,10 @@
-// File contains shared types for dapp-config
+import { InjectedWindowProvider } from '@polkadot/extension-inject/types';
+
+declare global {
+  interface Window {
+    injectedWeb3?: Record<string, InjectedWindowProvider>;
+  }
+}
 
 /**
  * The type of the environment the dapp is running in

--- a/libs/dapp-config/src/utils/findSubstrateWallet.ts
+++ b/libs/dapp-config/src/utils/findSubstrateWallet.ts
@@ -1,18 +1,85 @@
-import type { InjectedExtension } from '@polkadot/extension-inject/types';
+import type {
+  InjectedAccount,
+  InjectedExtension,
+  Unsubcall,
+} from '@polkadot/extension-inject/types';
+import { WalletId } from '@tangle-network/dapp-types';
+import WalletNotInstalledError from '@tangle-network/dapp-types/errors/WalletNotInstalledError';
+import { WALLET_CONFIG } from '../wallets';
 
+function ensureAccountsSubscribe(
+  extension: InjectedExtension,
+): InjectedExtension {
+  // if we don't have an accounts subscriber, create a new extension with the subscriber
+  if (!extension.accounts.subscribe) {
+    return {
+      ...extension,
+      accounts: {
+        ...extension.accounts,
+        subscribe: (
+          cb: (accounts: InjectedAccount[]) => void | Promise<void>,
+        ): Unsubcall => {
+          extension.accounts.get().then(cb).catch(console.error);
+
+          return (): void => {
+            // no unsubscribe needed, this is a single-shot
+          };
+        },
+      },
+    };
+  }
+
+  return extension;
+}
+
+/**
+ * Find and connect to the substrate wallet
+ * @param appName - Name of the application
+ * @param walletId - ID of the wallet
+ * @returns Injected extension
+ * @throws WalletNotInstalledError if the wallet is not installed
+ */
 async function findSubstrateWallet(
   appName: string,
-  extensionName: string,
-): Promise<InjectedExtension | undefined> {
-  try {
-    const { web3Enable } = await import('@polkadot/extension-dapp');
+  walletId: WalletId,
+): Promise<InjectedExtension> {
+  const walletName = WALLET_CONFIG[walletId].name;
+  const extension = window.injectedWeb3?.[walletName];
 
-    const extensions = await web3Enable(appName);
-
-    return extensions.find((extension) => extension.name === extensionName);
-  } catch (error) {
-    console.error('Error getting polkadot based wallet', error);
+  if (extension === undefined) {
+    throw new WalletNotInstalledError(walletId);
   }
+
+  if (extension.connect !== undefined) {
+    const ex = await extension.connect(appName);
+    return ensureAccountsSubscribe(ex);
+  }
+
+  if (extension.enable !== undefined) {
+    const injected = await extension.enable(appName);
+    return ensureAccountsSubscribe({
+      name: walletName,
+      version: extension.version || 'unknown',
+      ...injected,
+    });
+  }
+
+  // Fallback to the old way of enabling all the extensions
+  const { web3Enable, web3EnablePromise } = await import(
+    '@polkadot/extension-dapp'
+  );
+
+  const extensions = await (web3EnablePromise !== null
+    ? web3EnablePromise
+    : web3Enable(appName));
+
+  const ex = extensions.find((extension) => extension.name === walletName);
+  if (ex === undefined) {
+    throw new WalletNotInstalledError(walletId);
+  }
+
+  // Extension from @polkadot/extension-dapp already check for accounts subscription
+  return ex;
 }
 
 export default findSubstrateWallet;

--- a/libs/dapp-config/src/wallets/wallet-config.interface.ts
+++ b/libs/dapp-config/src/wallets/wallet-config.interface.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @tangle-network/
 // SPDX-License-Identifier: Apache-2.0
 
-import type { InjectedExtension } from '@polkadot/extension-inject/types';
+import type { InjectedWindowProvider } from '@polkadot/extension-inject/types';
 import type { SupportedBrowsers } from '@tangle-network/browser-utils/platform/getPlatformMetaData';
 
 export interface WalletConfig {
@@ -32,8 +32,12 @@ export interface WalletConfig {
 
   /**
    * a function that will tell weather the wallet is installed or reachable
+   * - true - indicates a **EVM** wallet available
+   * - InjectedWindowProvider - indicates a **Substrate** wallet available
    */
-  detect(appName: string): Promise<boolean | InjectedExtension | undefined>;
+  detect(
+    appName: string,
+  ): Promise<boolean | InjectedWindowProvider | undefined>;
 
   /**
    * a list of supported typed chain ids

--- a/libs/dapp-config/src/wallets/wallets-config.tsx
+++ b/libs/dapp-config/src/wallets/wallets-config.tsx
@@ -9,7 +9,6 @@ import {
   TalismanIcon,
   WalletConnectIcon,
 } from '@tangle-network/icons/wallets';
-import findSubstrateWallet from '../utils/findSubstrateWallet';
 import type { WalletConfig } from './wallet-config.interface';
 
 const ANY_EVM = [
@@ -54,7 +53,20 @@ const ANY_SUBSTRATE = [
   PresetTypedChainId.RococoPhala,
 ];
 
-export const WALLET_CONFIG: Record<number, WalletConfig> = {
+const detectSubstrateWallet = (walletName: string) => {
+  const extension = window.injectedWeb3?.[walletName];
+  if (extension === undefined) {
+    return;
+  }
+
+  if (extension.connect === undefined && extension.enable === undefined) {
+    return;
+  }
+
+  return extension;
+};
+
+export const WALLET_CONFIG: Record<WalletId, WalletConfig> = {
   // TODO: Should move all hardcoded wallet configs to connectors
   // https://wagmi.sh/examples/custom-connector
   [WalletId.MetaMask]: {
@@ -117,8 +129,8 @@ export const WALLET_CONFIG: Record<number, WalletConfig> = {
     title: `Polkadot{.js}`,
     platform: 'Substrate',
     enabled: true,
-    async detect(appName) {
-      return findSubstrateWallet(appName, 'polkadot-js');
+    async detect() {
+      return detectSubstrateWallet('polkadot-js');
     },
     supportedChainIds: [...ANY_SUBSTRATE],
     homeLink: 'https://polkadot.js.org/extension',
@@ -136,8 +148,8 @@ export const WALLET_CONFIG: Record<number, WalletConfig> = {
     title: 'Talisman',
     platform: 'Substrate',
     enabled: true,
-    detect(appName) {
-      return findSubstrateWallet(appName, 'talisman');
+    async detect() {
+      return detectSubstrateWallet('talisman');
     },
     supportedChainIds: [...ANY_SUBSTRATE],
     homeLink: 'https://talisman.xyz/',
@@ -155,8 +167,8 @@ export const WALLET_CONFIG: Record<number, WalletConfig> = {
     title: 'SubWallet',
     platform: 'Substrate',
     enabled: true,
-    detect(appName) {
-      return findSubstrateWallet(appName, 'subwallet-js');
+    async detect() {
+      return detectSubstrateWallet('subwallet-js');
     },
     supportedChainIds: [...ANY_SUBSTRATE],
     homeLink: 'https://www.subwallet.app/',

--- a/libs/dapp-types/src/WalletId.ts
+++ b/libs/dapp-types/src/WalletId.ts
@@ -3,7 +3,6 @@ export enum WalletId {
   MetaMask,
   WalletConnectV2,
   Rainbow,
-  OneWallet,
   Talisman,
   SubWallet,
 }

--- a/libs/polkadot-api-provider/src/ext-provider/polkadot-provider.ts
+++ b/libs/polkadot-api-provider/src/ext-provider/polkadot-provider.ts
@@ -10,7 +10,6 @@ import { u8aToString } from '@polkadot/util';
 import { LoggerService } from '@tangle-network/browser-utils';
 import { Wallet } from '@tangle-network/dapp-config';
 import findSubstrateWallet from '@tangle-network/dapp-config/utils/findSubstrateWallet';
-import WalletNotInstalledError from '@tangle-network/dapp-types/errors/WalletNotInstalledError';
 import { EventBus } from '@tangle-network/dapp-types/EventBus';
 import lodash from 'lodash';
 import { isValidAddress } from './is-valid-address';
@@ -38,8 +37,8 @@ export class PolkadotProvider extends EventBus<ExtensionProviderEvents> {
   private _accounts: PolkadotAccounts;
 
   constructor(
-    protected apiPromise: ApiPromise,
-    protected injectedExtension: InjectedExtension,
+    readonly apiPromise: ApiPromise,
+    readonly injectedExtension: InjectedExtension,
   ) {
     super();
     this.hookListeners();
@@ -180,12 +179,7 @@ export class PolkadotProvider extends EventBus<ExtensionProviderEvents> {
     wallet: Wallet,
   ): Promise<[ApiPromise, InjectedExtension]> {
     // Check whether the extension is existed or not
-    const currentExtension = await findSubstrateWallet(appName, wallet.name);
-
-    if (!currentExtension) {
-      logger.warn(`${wallet.title} extension isn't installed`);
-      throw new WalletNotInstalledError(wallet.id);
-    }
+    const currentExtension = await findSubstrateWallet(appName, wallet.id);
 
     // Initialize an ApiPromise
     const apiPromise = await PolkadotProvider.getApiPromise(endPoints, {

--- a/libs/polkadot-api-provider/src/webb-provider.ts
+++ b/libs/polkadot-api-provider/src/webb-provider.ts
@@ -73,9 +73,7 @@ export class WebbPolkadot
   }
 
   async awaitMetaDataCheck() {
-    /// delay some time till the UI is instantiated and then check if the dApp needs to update extension meta data
-    await new Promise((resolve) => setTimeout(resolve, 3000));
-    await this.provider.checkMetaDataUpdate();
+    return this.provider.checkMetaDataUpdate();
   }
 
   static async init(
@@ -106,8 +104,7 @@ export class WebbPolkadot
       provider,
       accounts,
     );
-    /// check metadata update
-    await instance.awaitMetaDataCheck();
+
     await apiPromise.isReady;
 
     const unsub = await instance.listenerBlocks();

--- a/libs/polkadot-api-provider/src/webb-provider.ts
+++ b/libs/polkadot-api-provider/src/webb-provider.ts
@@ -145,32 +145,14 @@ export class WebbPolkadot
   }
 
   async sign(message: string): Promise<string> {
-    const { web3Accounts, web3FromSource } = await import(
-      '@polkadot/extension-dapp'
-    );
-
     const account = await this.accounts.activeOrDefault;
     if (!account) {
       throw WebbError.from(WebbErrorCodes.NoAccountAvailable);
     }
 
-    const allAccounts = await web3Accounts();
-    const injectedAccount = allAccounts.find(
-      (acc) =>
-        acc.address === account.address &&
-        acc.meta.name === account.name &&
-        acc.meta.source === this.injectedExtension.name,
-    );
-
-    if (!injectedAccount) {
-      throw WebbError.from(WebbErrorCodes.NoAccountAvailable);
-    }
-
-    const injector = await web3FromSource(injectedAccount.meta.source);
-
     // this injector object has a signer and a signRaw method
     // to be able to sign raw bytes
-    const signRaw = injector?.signer?.signRaw;
+    const signRaw = this.injectedExtension.signer?.signRaw;
 
     if (!signRaw) {
       throw WebbError.from(WebbErrorCodes.NoSignRaw);

--- a/libs/tangle-shared-ui/src/components/UpdateMetadataButton/UpdateMetadataButton.tsx
+++ b/libs/tangle-shared-ui/src/components/UpdateMetadataButton/UpdateMetadataButton.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { MetadataDef } from '@polkadot/extension-inject/types';
-import { isAddress as isSubstrateAddress } from '@polkadot/util-crypto';
 import { HexString } from '@polkadot/util/types';
-import { useActiveAccount } from '@tangle-network/api-provider-environment/hooks/useActiveAccount';
+import { useActiveWallet } from '@tangle-network/api-provider-environment/hooks/useActiveWallet';
 import { TANGLE_TOKEN_DECIMALS } from '@tangle-network/dapp-config';
 import { RefreshLineIcon } from '@tangle-network/icons';
 import {
@@ -16,6 +15,7 @@ import { NetworkId } from '@tangle-network/ui-components/constants/networks';
 import isEqual from 'lodash/isEqual';
 import { FC, useCallback, useMemo, useState } from 'react';
 import useNetworkStore from '../../context/useNetworkStore';
+import useAgnosticAccountInfo from '../../hooks/useAgnosticAccountInfo';
 import useLocalStorage, {
   LocalStorageKey,
   SubstrateWalletsMetadataEntry,
@@ -23,12 +23,11 @@ import useLocalStorage, {
 import usePromise from '../../hooks/usePromise';
 import useSubstrateInjectedExtension from '../../hooks/useSubstrateInjectedExtension';
 import { getApiPromise } from '../../utils/polkadot/api';
-import { useActiveWallet } from '@tangle-network/api-provider-environment/hooks/useActiveWallet';
 
 const UpdateMetadataButton: FC = () => {
   const [isHidden, setIsHidden] = useState(false);
 
-  const [activeAccount] = useActiveAccount();
+  const { substrateAddress } = useAgnosticAccountInfo();
   const [activeWallet] = useActiveWallet();
   const injector = useSubstrateInjectedExtension();
   const { network } = useNetworkStore();
@@ -89,16 +88,10 @@ const UpdateMetadataButton: FC = () => {
     network.tokenSymbol,
   ]);
 
-  const isSubstrateAccount = useMemo(() => {
-    return activeAccount !== null
-      ? isSubstrateAddress(activeAccount.address)
-      : null;
-  }, [activeAccount]);
-
   const handleClick = async () => {
     if (
       injector === null ||
-      activeAccount === null ||
+      substrateAddress === null ||
       network.ss58Prefix === undefined
     ) {
       return;
@@ -153,7 +146,7 @@ const UpdateMetadataButton: FC = () => {
     isMetadataUpToDate === null ||
     isMetadataUpToDate ||
     isHidden ||
-    !isSubstrateAccount
+    substrateAddress === null
   ) {
     return null;
   }

--- a/libs/tangle-shared-ui/src/hooks/usePromise.ts
+++ b/libs/tangle-shared-ui/src/hooks/usePromise.ts
@@ -58,21 +58,21 @@ function usePromise<T>(factory: () => Promise<T>, fallbackValue: T) {
 
     factory()
       .then((newResult) => {
-        if (!isMounted.current || !isSubscribed) {
+        if (!isMounted.current || !isSubscribed.current) {
           return;
         }
 
         setResult(newResult);
       })
       .catch((possibleError: unknown) => {
-        if (!isMounted.current || !isSubscribed) {
+        if (!isMounted.current || !isSubscribed.current) {
           return;
         }
 
         setError(ensureError(possibleError));
       })
       .finally(() => {
-        if (!isMounted.current || !isSubscribed) {
+        if (!isMounted.current || !isSubscribed.current) {
           return;
         }
 

--- a/libs/tangle-shared-ui/src/hooks/useSubstrateInjectedExtension.ts
+++ b/libs/tangle-shared-ui/src/hooks/useSubstrateInjectedExtension.ts
@@ -1,29 +1,15 @@
 import { InjectedExtension } from '@polkadot/extension-inject/types';
-import { useCallback, useEffect } from 'react';
-import { findInjectorForAddress } from '../utils/polkadot/api';
-import useAgnosticAccountInfo from './useAgnosticAccountInfo';
-import usePromise from './usePromise';
+import { useWebContext } from '@tangle-network/api-provider-environment';
+import { PolkadotProvider } from '@tangle-network/polkadot-api-provider';
 
 const useSubstrateInjectedExtension = (): InjectedExtension | null => {
-  const { substrateAddress } = useAgnosticAccountInfo();
+  const { activeApi } = useWebContext();
 
-  const { result: injector, refresh } = usePromise<InjectedExtension | null>(
-    useCallback(() => {
-      if (substrateAddress === null) {
-        return Promise.resolve(null);
-      }
+  if (activeApi instanceof PolkadotProvider) {
+    return activeApi.injectedExtension;
+  }
 
-      return findInjectorForAddress(substrateAddress);
-    }, [substrateAddress]),
-    null,
-  );
-
-  // Re-fetch the injector when the active account changes.
-  useEffect(() => {
-    refresh();
-  }, [substrateAddress, refresh]);
-
-  return injector;
+  return null;
 };
 
 export default useSubstrateInjectedExtension;

--- a/libs/tangle-shared-ui/src/hooks/useSubstrateInjectedExtension.ts
+++ b/libs/tangle-shared-ui/src/hooks/useSubstrateInjectedExtension.ts
@@ -1,27 +1,27 @@
 import { InjectedExtension } from '@polkadot/extension-inject/types';
-import { useActiveAccount } from '@tangle-network/api-provider-environment/hooks/useActiveAccount';
 import { useCallback, useEffect } from 'react';
 import { findInjectorForAddress } from '../utils/polkadot/api';
+import useAgnosticAccountInfo from './useAgnosticAccountInfo';
 import usePromise from './usePromise';
 
 const useSubstrateInjectedExtension = (): InjectedExtension | null => {
-  const [activeAccount] = useActiveAccount();
+  const { substrateAddress } = useAgnosticAccountInfo();
 
   const { result: injector, refresh } = usePromise<InjectedExtension | null>(
     useCallback(() => {
-      if (activeAccount === null) {
+      if (substrateAddress === null) {
         return Promise.resolve(null);
       }
 
-      return findInjectorForAddress(activeAccount.address);
-    }, [activeAccount]),
+      return findInjectorForAddress(substrateAddress);
+    }, [substrateAddress]),
     null,
   );
 
   // Re-fetch the injector when the active account changes.
   useEffect(() => {
     refresh();
-  }, [activeAccount, refresh]);
+  }, [substrateAddress, refresh]);
 
   return injector;
 };

--- a/libs/tangle-shared-ui/src/hooks/useWallet.ts
+++ b/libs/tangle-shared-ui/src/hooks/useWallet.ts
@@ -1,4 +1,8 @@
-import { web3Accounts, web3Enable } from '@polkadot/extension-dapp';
+import {
+  web3Accounts,
+  web3Enable,
+  web3EnablePromise,
+} from '@polkadot/extension-dapp';
 import useProviderStore from '../context/useProviderStore';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -66,7 +70,9 @@ const useWallet = () => {
       setIsConnecting(true);
 
       // Request access to any installed Substrate wallet extensions.
-      const extensions = await web3Enable(appName);
+      const extensions = await (web3EnablePromise !== null
+        ? web3EnablePromise
+        : web3Enable(appName));
 
       // No extension found or the user did not grant permission.
       if (extensions.length === 0) {

--- a/libs/tangle-shared-ui/src/utils/polkadot/api.ts
+++ b/libs/tangle-shared-ui/src/utils/polkadot/api.ts
@@ -55,7 +55,7 @@ export const getApiRx = async (endpoint: string): Promise<ApiRx> => {
 export const findInjectorForAddress = async (
   address: string,
 ): Promise<InjectedExtension | null> => {
-  const { web3Enable, web3FromAddress } = await import(
+  const { web3Enable, web3EnablePromise, web3FromAddress } = await import(
     '@polkadot/extension-dapp'
   );
 
@@ -67,7 +67,9 @@ export const findInjectorForAddress = async (
     return cachedInjector;
   }
 
-  const extensions = await web3Enable('Tangle');
+  const extensions = await (web3EnablePromise !== null
+    ? web3EnablePromise
+    : web3Enable('Tangle'));
 
   // No wallet extensions installed in the browser.
   if (extensions.length === 0) {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,3 +1,5 @@
+import type { InjectedWindowProvider } from '@polkadot/extension-inject/types';
+
 /**
  * SVG files can be imported as React components
  * @see https://react-svgr.com/docs/next/#typescript
@@ -11,4 +13,10 @@ declare module '*.svg' {
 declare module '*.svg?url' {
   const content: any;
   export default content;
+}
+
+declare global {
+  interface Window {
+    injectedWeb3?: Record<string, InjectedWindowProvider>;
+  }
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,5 +1,3 @@
-import type { InjectedWindowProvider } from '@polkadot/extension-inject/types';
-
 /**
  * SVG files can be imported as React components
  * @see https://react-svgr.com/docs/next/#typescript
@@ -11,12 +9,6 @@ declare module '*.svg' {
 }
 
 declare module '*.svg?url' {
-  const content: any;
+  const content: string;
   export default content;
-}
-
-declare global {
-  interface Window {
-    injectedWeb3?: Record<string, InjectedWindowProvider>;
-  }
 }


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Fix the issue of the Talisman wallet repeatedly appearing during page re-renders.
- Ensure that only the selected wallet opens when connecting to a Substrate wallet, rather than all available Substrate wallets.
- Call `web3Enable` only once, and use `web3EnablePromise` if it is initialized. 
	- **Note:** _Ideally, avoid calling `web3Enable` as it triggers the connection for all installed Substrate wallets._
- Utilize the injected extension from the active API instead of reinitializing and searching for the target extension, which also causes all unconnected Substrate wallets to appear.
- Simplify the `sign` method by directly using the injected extension signer from the API.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Resolved 2 items in https://github.com/tangle-network/dapp/issues/2835

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

https://github.com/user-attachments/assets/d38da6db-cdd4-4f5c-9d3b-398c854838af