### PR TITLE
refactor(repo): replacing StatsItem, KeyStatsItem component to ui-components

### DIFF
--- a/apps/tangle-dapp/src/components/KeyStatsItem/KeyStatsItemVariant.ts
+++ b/apps/tangle-dapp/src/components/KeyStatsItem/KeyStatsItemVariant.ts
@@ -1,7 +1,0 @@
-enum KeyStatsItemVariant {
-  Left,
-  Center,
-  Right,
-}
-
-export default KeyStatsItemVariant;

--- a/apps/tangle-dapp/src/components/KeyStatsItem/index.ts
+++ b/apps/tangle-dapp/src/components/KeyStatsItem/index.ts
@@ -1,2 +1,0 @@
-export * from './KeyStatsItem';
-export { default as KeyStatsItem } from './KeyStatsItem';

--- a/apps/tangle-dapp/src/components/NominatorStatsItem/NominatorStatsItem.tsx
+++ b/apps/tangle-dapp/src/components/NominatorStatsItem/NominatorStatsItem.tsx
@@ -1,10 +1,5 @@
-import {
-  InfoIconWithTooltip,
-  SkeletonLoader,
-  Typography,
-} from '@tangle-network/ui-components';
+import { StatsItem } from '@tangle-network/ui-components';
 import type { FC, ReactNode } from 'react';
-import { twMerge } from 'tailwind-merge';
 
 export type NominatorStatsItemProps = {
   title: string;
@@ -14,42 +9,6 @@ export type NominatorStatsItemProps = {
   isError: boolean;
 };
 
-export const NominatorStatsItem: FC<NominatorStatsItemProps> = ({
-  title,
-  tooltip,
-  className,
-  children,
-  isError,
-}) => {
-  return (
-    <div className={twMerge('flex flex-col gap-2', className)}>
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-center">
-        <div className="flex items-center gap-0.5">
-          {children === null ? (
-            <SkeletonLoader className="w-[100px]" size="lg" />
-          ) : isError ? (
-            'Error'
-          ) : (
-            <div className="flex items-center gap-2">
-              <Typography
-                variant="h4"
-                fw="bold"
-                className="text-mono-140 dark:text-mono-40"
-              >
-                {children}
-              </Typography>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="flex items-center gap-0.5">
-        <Typography variant="body1" className="text-mono-140 dark:text-mono-40">
-          {title}
-        </Typography>
-
-        {tooltip && <InfoIconWithTooltip content={tooltip} />}
-      </div>
-    </div>
-  );
+export const NominatorStatsItem: FC<NominatorStatsItemProps> = (props) => {
+  return <StatsItem {...props} />;
 };

--- a/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
+++ b/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
@@ -14,7 +14,7 @@ import {
 import { useMemo } from 'react';
 import useActivePoints from '../../data/points/useActivePoints';
 import useAccountRewardInfo from '../../data/rewards/useAccountRewardInfo';
-import KeyStatsItem from '../KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import ClaimRewardAction from './ClaimRewardAction';
 
 const RewardsAndPoints = () => {

--- a/apps/tangle-dapp/src/components/index.ts
+++ b/apps/tangle-dapp/src/components/index.ts
@@ -1,7 +1,6 @@
 export * from './BondedTokensBalanceInfo';
 export { default as CardWithTangleLogo } from './CardWithTangleLogo';
 export * from './HeaderChip';
-export * from './KeyStatsItem';
 export * from './NominatorStatsItem';
 export * from './Sidebar';
 export * from './skeleton';

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/ActiveValidatorsKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/ActiveValidatorsKeyStat.tsx
@@ -1,7 +1,7 @@
 import { EMPTY_VALUE_PLACEHOLDER } from '@tangle-network/ui-components/constants';
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useActiveAndDelegationCountSubscription from '../../data/KeyStats/useActiveAndDelegationCountSubscription';
 
 const ActiveValidatorsKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/ActualStakedPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/ActualStakedPercentageKeyStat.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useActualStakedPercentage from '../../data/staking/useActualStakedPercentage';
 
 const ActualStakedPercentageKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/IdealStakedPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/IdealStakedPercentageKeyStat.tsx
@@ -1,7 +1,7 @@
 import { EMPTY_VALUE_PLACEHOLDER } from '@tangle-network/ui-components/constants';
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useIdealStakePercentage from '../../data/KeyStats/useIdealStakePercentage';
 
 const IdealStakedPercentageKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/InflationPercentageKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/InflationPercentageKeyStat.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useInflationPercentage from '../../data/KeyStats/useInflationPercentage';
 
 const InflationPercentageKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/ValidatorCountKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/ValidatorCountKeyStat.tsx
@@ -1,7 +1,7 @@
 import { EMPTY_VALUE_PLACEHOLDER } from '@tangle-network/ui-components/constants';
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useValidatorCountSubscription from '../../data/KeyStats/useValidatorsCountSubscription';
 
 const ValidatorCountKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/KeyStatsContainer/WaitingValidatorsKeyStat.tsx
+++ b/apps/tangle-dapp/src/containers/KeyStatsContainer/WaitingValidatorsKeyStat.tsx
@@ -1,7 +1,7 @@
 import { EMPTY_VALUE_PLACEHOLDER } from '@tangle-network/ui-components/constants';
 import { FC } from 'react';
 
-import KeyStatsItem from '../../components/KeyStatsItem/KeyStatsItem';
+import { KeyStatsItem } from '@tangle-network/ui-components';
 import useWaitingCountSubscription from '../../data/KeyStats/useWaitingCountSubscription';
 
 const WaitingValidatorsKeyStat: FC = () => {

--- a/apps/tangle-dapp/src/containers/NominatorStatsContainer.tsx
+++ b/apps/tangle-dapp/src/containers/NominatorStatsContainer.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   CardVariant,
   Divider,
+  StatsItem,
 } from '@tangle-network/ui-components';
 import {
   EMPTY_VALUE_PLACEHOLDER,
@@ -16,7 +17,6 @@ import {
 import { type FC, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
-import { NominatorStatsItem } from '../components';
 import useBalances from '../data/balances/useBalances';
 import useTotalPayoutRewards from '../data/nomination/useTotalPayoutRewards';
 import useIsBondedOrNominating from '../data/staking/useIsBondedOrNominating';
@@ -74,18 +74,15 @@ const NominatorStatsContainer: FC = () => {
       <div className="flex flex-col w-full gap-4 md:flex-row">
         <Card variant={CardVariant.GLASS} className={cardClass}>
           <div className="grid grid-cols-2 gap-2">
-            <NominatorStatsItem
-              title="Free Balance"
-              isError={balancesError !== null}
-            >
+            <StatsItem title="Free Balance" isError={balancesError !== null}>
               {activeAccountAddress === null
                 ? EMPTY_VALUE_PLACEHOLDER
                 : freeBalance === null
                   ? null
                   : formatTangleBalance(freeBalance, nativeTokenSymbol)}
-            </NominatorStatsItem>
+            </StatsItem>
 
-            <NominatorStatsItem
+            <StatsItem
               title="Unclaimed Payouts"
               isError={totalPayoutRewardsError !== null}
             >
@@ -93,7 +90,7 @@ const NominatorStatsContainer: FC = () => {
                 ? EMPTY_VALUE_PLACEHOLDER
                 : formatTangleBalance(totalPayoutRewards) +
                   ` ${nativeTokenSymbol}`}
-            </NominatorStatsItem>
+            </StatsItem>
           </div>
 
           <Divider className="my-6 bg-mono-0 dark:bg-mono-160" />
@@ -137,7 +134,7 @@ const NominatorStatsContainer: FC = () => {
 
         <Card variant={CardVariant.GLASS} className={cardClass}>
           <div className="grid grid-cols-2 gap-2">
-            <NominatorStatsItem
+            <StatsItem
               title={`Total Staked ${nativeTokenSymbol}`}
               tooltip="The total amount of tokens you have bonded for nominating."
               isError={false}
@@ -147,7 +144,7 @@ const NominatorStatsContainer: FC = () => {
                 : bondedAmountBalance === null
                   ? null
                   : bondedAmountBalance}
-            </NominatorStatsItem>
+            </StatsItem>
 
             <UnbondingStatsItem />
           </div>

--- a/libs/ui-components/src/components/Stats/KeyStatsItem.tsx
+++ b/libs/ui-components/src/components/Stats/KeyStatsItem.tsx
@@ -4,26 +4,12 @@ import {
   SkeletonLoader,
   Typography,
 } from '@tangle-network/ui-components';
-import { FC, ReactNode, useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
-import KeyStatsItemVariant from './KeyStatsItemVariant';
+import { KeyStatsItemProps } from './types';
 import { isPrimitive } from '@tangle-network/dapp-types';
 
-export type KeyStatsItemProps = {
-  title: string;
-  prefix?: string;
-  suffix?: string;
-  tooltip?: string;
-  className?: string;
-  showDataBeforeLoading?: boolean;
-  hideErrorNotification?: boolean;
-  children?: ReactNode;
-  error: Error | null;
-  isLoading?: boolean;
-  variant?: KeyStatsItemVariant;
-};
-
-const KeyStatsItem: FC<KeyStatsItemProps> = ({
+export const KeyStatsItem: FC<KeyStatsItemProps> = ({
   title,
   tooltip,
   className,
@@ -98,5 +84,3 @@ const KeyStatsItem: FC<KeyStatsItemProps> = ({
     </div>
   );
 };
-
-export default KeyStatsItem;

--- a/libs/ui-components/src/components/Stats/StatsItem.tsx
+++ b/libs/ui-components/src/components/Stats/StatsItem.tsx
@@ -1,0 +1,48 @@
+import {
+  InfoIconWithTooltip,
+  SkeletonLoader,
+  Typography,
+} from '@tangle-network/ui-components';
+import type { FC } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { StatsItemProps } from './types';
+
+export const StatsItem: FC<StatsItemProps> = ({
+  title,
+  tooltip,
+  className,
+  children,
+  isError,
+}) => {
+  return (
+    <div className={twMerge('flex flex-col gap-2', className)}>
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-0.5">
+          {children === null ? (
+            <SkeletonLoader className="w-[100px]" size="lg" />
+          ) : isError ? (
+            'Error'
+          ) : (
+            <div className="flex items-center gap-2">
+              <Typography
+                variant="h4"
+                fw="bold"
+                className="text-mono-140 dark:text-mono-40"
+              >
+                {children}
+              </Typography>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-0.5">
+        <Typography variant="body1" className="text-mono-140 dark:text-mono-40">
+          {title}
+        </Typography>
+
+        {tooltip && <InfoIconWithTooltip content={tooltip} />}
+      </div>
+    </div>
+  );
+};

--- a/libs/ui-components/src/components/Stats/index.ts
+++ b/libs/ui-components/src/components/Stats/index.ts
@@ -1,1 +1,4 @@
 export * from './Stats';
+export { StatsItem } from './StatsItem';
+export { KeyStatsItem } from './KeyStatsItem';
+export { KeyStatsItemVariant } from './types';

--- a/libs/ui-components/src/components/Stats/types.ts
+++ b/libs/ui-components/src/components/Stats/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { PropsOf, IComponentBase } from '../../types';
 
 import { TitleWithInfoProps } from '../TitleWithInfo/types';
@@ -9,4 +10,38 @@ export interface StatItem {
 
 export interface StatsProps extends PropsOf<'div'>, IComponentBase {
   items: Array<StatItem>;
+}
+
+/**
+ * StatsItem types
+ */
+export type StatsItemProps = {
+  title: string | ReactNode;
+  tooltip?: string | ReactNode;
+  className?: string;
+  children: ReactNode | null;
+  isError: boolean;
+};
+
+/**
+ * KeyStatsItem types
+ */
+export type KeyStatsItemProps = {
+  title: string;
+  prefix?: string;
+  suffix?: string;
+  tooltip?: string;
+  className?: string;
+  showDataBeforeLoading?: boolean;
+  hideErrorNotification?: boolean;
+  children?: ReactNode;
+  error: Error | null;
+  isLoading?: boolean;
+  variant?: KeyStatsItemVariant;
+};
+
+export enum KeyStatsItemVariant {
+  Left,
+  Center,
+  Right,
 }


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Moving `NominatorStatsItem` and `KeyStatsItem` from Tangle-Dapp to ui-components. These can be re-used in Tangle-Cloud

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [x] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._
