### PR TITLE
fix(tools): Update Tangle chains Info

### DIFF
--- a/libs/dapp-config/src/chains/evm/customChains/tangleMainnetEVM.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/tangleMainnetEVM.ts
@@ -8,9 +8,9 @@ import {
 
 const tangleMainnetEVM = defineChain({
   id: EVMChainId.TangleMainnetEVM,
-  name: 'Tangle Mainnet',
+  name: 'Tangle',
   nativeCurrency: {
-    name: 'Tangle Network Token',
+    name: 'Tangle',
     symbol: 'TNT',
     decimals: 18,
   },

--- a/libs/dapp-config/src/chains/evm/customChains/tangleTestnetEVM.ts
+++ b/libs/dapp-config/src/chains/evm/customChains/tangleTestnetEVM.ts
@@ -16,7 +16,7 @@ const tangleTestnetEVM = defineChain({
     },
   },
   nativeCurrency: {
-    name: 'Test Tangle Network Token',
+    name: 'Testnet Tangle Network Token',
     symbol: 'tTNT',
     decimals: 18,
   },


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

Update Tangle's testnet and mainnet chain information to match the Ethereum chain list [testnet](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-3799.json) and [mainnet](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-5845.json) to avoid warnings when users add the chain to their EVM wallet.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes `NaN`.

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

| Testnet  | Mainnet |
| ------------- | --------------- |
| <img src="https://github.com/user-attachments/assets/350f8013-51f5-4afa-b271-913ad4493a7a" alt="CleanShot 2025-03-06 at 01 26 47@2x" /> | <img src="https://github.com/user-attachments/assets/c9a04445-b6f1-4277-877a-02943fe78c0a" alt="CleanShot 2025-03-06 at 01 27 31@2x" /> |


