### PR TITLE
fix(tangle-dapp): Fix bridge page crash when connected to a Substrate account

### DIFF
--- a/apps/tangle-dapp/src/features/bridge/hooks/useAssets.ts
+++ b/apps/tangle-dapp/src/features/bridge/hooks/useAssets.ts
@@ -12,6 +12,7 @@ import { makeExplorerUrl } from '@tangle-network/api-provider-environment/transa
 import convertDecimalToBN from '@tangle-network/tangle-shared-ui/utils/convertDecimalToBn';
 import Decimal from 'decimal.js';
 import { assertEvmAddress } from '@tangle-network/ui-components/utils/assertEvmAddress';
+import { isEvmAddress } from '@tangle-network/ui-components';
 
 /**
  * Hook to get the list of formatted bridge assets that is used to display on the AssetList modal.
@@ -43,7 +44,9 @@ export default function useAssets(
 
   const { data: nativeTokenBalance } = useBalance({
     address: activeAccount?.address
-      ? assertEvmAddress(activeAccount.address)
+      ? isEvmAddress(activeAccount.address)
+        ? activeAccount.address
+        : undefined
       : undefined,
     chainId: selectedSourceChain.id,
     query: {

--- a/apps/tangle-dapp/src/features/bridge/hooks/useAssets.ts
+++ b/apps/tangle-dapp/src/features/bridge/hooks/useAssets.ts
@@ -12,7 +12,7 @@ import { makeExplorerUrl } from '@tangle-network/api-provider-environment/transa
 import convertDecimalToBN from '@tangle-network/tangle-shared-ui/utils/convertDecimalToBn';
 import Decimal from 'decimal.js';
 import { assertEvmAddress } from '@tangle-network/ui-components/utils/assertEvmAddress';
-import { isEvmAddress } from '@tangle-network/ui-components';
+import useAgnosticAccountInfo from '@tangle-network/tangle-shared-ui/hooks/useAgnosticAccountInfo';
 
 /**
  * Hook to get the list of formatted bridge assets that is used to display on the AssetList modal.
@@ -25,6 +25,8 @@ export default function useAssets(
   sourceTypedChainId: number,
   tokenBalances: Partial<Record<PresetTypedChainId, BridgeTokenWithBalance[]>>,
 ): AssetConfig[] {
+  const { evmAddress } = useAgnosticAccountInfo();
+
   const selectedSourceChain = useBridgeStore(
     useShallow((store) => store.selectedSourceChain),
   );
@@ -43,14 +45,10 @@ export default function useAssets(
     sourceTypedChainId === PresetTypedChainId.TangleTestnetEVM;
 
   const { data: nativeTokenBalance } = useBalance({
-    address: activeAccount?.address
-      ? isEvmAddress(activeAccount.address)
-        ? activeAccount.address
-        : undefined
-      : undefined,
+    address: evmAddress !== null ? evmAddress : undefined,
     chainId: selectedSourceChain.id,
     query: {
-      enabled: activeAccount !== null,
+      enabled: evmAddress !== null,
     },
   });
 


### PR DESCRIPTION
## Summary of changes

- Fixed a crash on the bridge page that occurred when the dApp was connected to a Substrate account.

### Proposed area of change

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Screen Recording

https://github.com/user-attachments/assets/4ce54b90-dec1-416a-abd4-785f15b0f177