### PR TITLE
chore(tangle-dapp): Add switch wallet button for bridge

### DIFF
--- a/libs/tangle-shared-ui/src/components/ConnectWalletButton/ConnectWalletButton.tsx
+++ b/libs/tangle-shared-ui/src/components/ConnectWalletButton/ConnectWalletButton.tsx
@@ -41,14 +41,12 @@ const ConnectWalletButton = ({
       return null;
     } else if (isEvmAddress(activeAccount.address)) {
       return activeAccount.address;
-    } else if (!showChainSpecificWallets && network.ss58Prefix === undefined) {
+    } else if (network.ss58Prefix === undefined) {
       return assertSubstrateAddress(activeAccount.address);
-    } else if (!showChainSpecificWallets) {
+    } else {
       return toSubstrateAddress(activeAccount.address, network.ss58Prefix);
     }
-
-    return null;
-  }, [activeAccount?.address, network.ss58Prefix, showChainSpecificWallets]);
+  }, [activeAccount?.address, network.ss58Prefix]);
 
   const isReady =
     !isConnecting && !loading && activeWallet && activeAccount !== null;


### PR DESCRIPTION
## Summary of changes

- If the user is connected to a non-EVM wallet on the bridge page, they will be prompted to switch to compatible wallet before performing any bridge action.

### Proposed area of change

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

- Closes #2824

### Screen Recording

https://github.com/user-attachments/assets/985a8e06-3477-48f0-b725-1fa79559afa7