### PR TITLE
refactor(tangle-dapp): Use 0 instead of value placeholders

### DIFF
--- a/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
+++ b/apps/tangle-dapp/src/components/account/RewardsAndPoints.tsx
@@ -79,7 +79,7 @@ const RewardsAndPoints = () => {
             className="text-mono-140 dark:text-mono-40"
             component="span"
           >
-            {totalRewardsFormatted ?? EMPTY_VALUE_PLACEHOLDER}{' '}
+            {totalRewardsFormatted ?? 0}{' '}
           </Typography>
 
           <Typography

--- a/apps/tangle-dapp/src/components/tables/Vaults/index.tsx
+++ b/apps/tangle-dapp/src/components/tables/Vaults/index.tsx
@@ -66,9 +66,10 @@ const getColumns = (nativeTokenSymbol: string) => [
     header: () => 'Available',
     cell: (props) => {
       const value = props.getValue();
+
       const fmtAvailable =
         value === undefined
-          ? EMPTY_VALUE_PLACEHOLDER
+          ? 0
           : formatDisplayAmount(
               value,
               props.row.original.decimals,
@@ -87,9 +88,10 @@ const getColumns = (nativeTokenSymbol: string) => [
     header: () => 'Deposits',
     cell: (props) => {
       const value = props.getValue();
+
       const fmtDeposits =
         value === undefined
-          ? EMPTY_VALUE_PLACEHOLDER
+          ? 0
           : formatDisplayAmount(
               value,
               props.row.original.decimals,
@@ -113,9 +115,10 @@ const getColumns = (nativeTokenSymbol: string) => [
     ),
     cell: (props) => {
       const value = props.getValue();
+
       const fmtRewards =
         value === undefined
-          ? EMPTY_VALUE_PLACEHOLDER
+          ? 0
           : formatDisplayAmount(
               value,
               props.row.original.decimals,
@@ -146,7 +149,7 @@ const getColumns = (nativeTokenSymbol: string) => [
 
       const fmtTvl =
         tvl === undefined
-          ? EMPTY_VALUE_PLACEHOLDER
+          ? 0
           : formatDisplayAmount(
               tvl,
               props.row.original.decimals,


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- 🔧 Small change: Tables & rewards should use `0` if there's no deposits or data, instead of `--` which should be used for loading/unavailable states.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2831

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

![Screenshot 2025-03-10 at 01 11 37](https://github.com/user-attachments/assets/f28361b8-f143-45cb-a01f-f0538f3117a9)
