### PR TITLE
fix(tangle-shared-ui): Fix Incorrect Vault Data Display

### DIFF
--- a/apps/tangle-dapp/src/components/tables/Vaults/index.tsx
+++ b/apps/tangle-dapp/src/components/tables/Vaults/index.tsx
@@ -8,7 +8,6 @@ import Button from '@tangle-network/ui-components/components/buttons/Button';
 import { CircularProgress } from '@tangle-network/ui-components/components/CircularProgress';
 import { Table } from '@tangle-network/ui-components/components/Table';
 import { TableVariant } from '@tangle-network/ui-components/components/Table/types';
-import { EMPTY_VALUE_PLACEHOLDER } from '@tangle-network/ui-components/constants';
 import { Typography } from '@tangle-network/ui-components/typography/Typography';
 import {
   AmountFormatStyle,
@@ -232,7 +231,7 @@ const VaultsTable: FC<Props> = ({
   emptyTableProps,
   loadingTableProps,
   tableProps,
-  isLoading: isLoadingProp,
+  isLoading,
 }) => {
   const nativeTokenSymbol = useNetworkStore(
     (store) => store.network.tokenSymbol,
@@ -256,8 +255,6 @@ const VaultsTable: FC<Props> = ({
     ),
   );
 
-  const isLoading = isLoadingProp || data === null;
-
   if (isLoading) {
     return (
       <TableStatus
@@ -268,7 +265,7 @@ const VaultsTable: FC<Props> = ({
         className={loadingTableProps?.className}
       />
     );
-  } else if (data.length === 0) {
+  } else if (data === null || data.length === 0) {
     return (
       <TableStatus
         title="No Vaults Found"

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeAssetIds.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeAssetIds.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { map, of } from 'rxjs';
 import useApiRx from '../../hooks/useApiRx';
 import { RestakeAssetId } from '../../types';
+import { TangleError, TangleErrorCode } from '../../types/error';
 import createRestakeAssetId from '../../utils/createRestakeAssetId';
 import useVaultsPotAccounts from '../rewards/useVaultsPotAccounts';
 
@@ -30,7 +31,7 @@ const useRestakeAssetIds = () => {
     useCallback(
       (api) => {
         if (vaultPotAccounts === null) {
-          return null;
+          return new TangleError(TangleErrorCode.INVALID_PARAMS);
         }
 
         const vaultIds = vaultPotAccounts.keys().toArray();

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeAssets.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeAssets.ts
@@ -182,9 +182,6 @@ const useRestakeAssets = () => {
         return await fetchErc20TokenMetadata(viemPublicClient, evmAssetIds);
       }, [evmAssetIds, viemPublicClient]),
       null,
-      {
-        enabled: evmAssetIds !== null && viemPublicClient !== null,
-      },
     );
 
   const evmAssets = useMemo(() => {

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeAssets.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeAssets.ts
@@ -11,6 +11,7 @@ import useApiRx from '../../hooks/useApiRx';
 import usePromise from '../../hooks/usePromise';
 import useViemPublicClient from '../../hooks/useViemPublicClient';
 import { RestakeAssetId } from '../../types';
+import { TangleError, TangleErrorCode } from '../../types/error';
 import { RestakeAsset, RestakeAssetMetadata } from '../../types/restake';
 import assertRestakeAssetId from '../../utils/assertRestakeAssetId';
 import createRestakeAssetId from '../../utils/createRestakeAssetId';
@@ -48,11 +49,8 @@ const useRestakeAssets = () => {
   const { result: rewardVaults, isLoading: isLoadingRewardVaults } = useApiRx(
     useCallback(
       (api) => {
-        if (
-          vaultPotAccounts === null ||
-          api.query.rewards?.rewardVaultsPotAccount === undefined
-        ) {
-          return null;
+        if (vaultPotAccounts === null) {
+          return new TangleError(TangleErrorCode.INVALID_PARAMS);
         }
 
         // Retrieve all vaults that have pot accounts.

--- a/libs/tangle-shared-ui/src/data/rewards/useVaultRewards.ts
+++ b/libs/tangle-shared-ui/src/data/rewards/useVaultRewards.ts
@@ -3,6 +3,7 @@ import useApiRx from '../../hooks/useApiRx';
 import useVaultPotAccount from './useVaultsPotAccounts';
 import { map } from 'rxjs';
 import { BN } from '@polkadot/util';
+import { TangleError, TangleErrorCode } from '../../types/error';
 
 const useVaultRewards = () => {
   const { result: vaultPotAccounts } = useVaultPotAccount();
@@ -11,11 +12,7 @@ const useVaultRewards = () => {
     useCallback(
       (apiRx) => {
         if (vaultPotAccounts === null) {
-          return null;
-        }
-
-        if (apiRx.query.balances?.account === undefined) {
-          return null;
+          return new TangleError(TangleErrorCode.INVALID_PARAMS);
         }
 
         const vaultPotAccountEntries = Array.from(vaultPotAccounts.entries());

--- a/libs/tangle-shared-ui/src/data/rewards/useVaultsPotAccounts.ts
+++ b/libs/tangle-shared-ui/src/data/rewards/useVaultsPotAccounts.ts
@@ -6,10 +6,6 @@ import { useCallback } from 'react';
 const useVaultsPotAccounts = () => {
   const result = useApiRx(
     useCallback((api) => {
-      if (api.query.rewards?.rewardVaultsPotAccount === undefined) {
-        return null;
-      }
-
       return api.query.rewards.rewardVaultsPotAccount.entries().pipe(
         map((entries) => {
           const primitiveEntries = entries

--- a/libs/tangle-shared-ui/src/hooks/useApiRx.ts
+++ b/libs/tangle-shared-ui/src/hooks/useApiRx.ts
@@ -45,6 +45,9 @@ const useApiRx = <T>(factory: ObservableFactory<T>) => {
       return await getApiRx(rpcEndpoint);
     }, [rpcEndpoint]),
     null,
+    {
+      enabled: rpcEndpoint !== undefined,
+    },
   );
 
   const reset = useCallback(() => {
@@ -123,6 +126,11 @@ const useApiRx = <T>(factory: ObservableFactory<T>) => {
       subscription.unsubscribe();
     };
   }, [factory, apiRx, reset]);
+
+  // Reset the result when the RPC endpoint changes.
+  useEffect(() => {
+    setResult(null);
+  }, [rpcEndpoint]);
 
   return { result, isLoading, error };
 };

--- a/libs/tangle-shared-ui/src/hooks/useApiRx.ts
+++ b/libs/tangle-shared-ui/src/hooks/useApiRx.ts
@@ -45,9 +45,6 @@ const useApiRx = <T>(factory: ObservableFactory<T>) => {
       return await getApiRx(rpcEndpoint);
     }, [rpcEndpoint]),
     null,
-    {
-      enabled: rpcEndpoint !== undefined,
-    },
   );
 
   const reset = useCallback(() => {

--- a/libs/tangle-shared-ui/src/hooks/usePromise.ts
+++ b/libs/tangle-shared-ui/src/hooks/usePromise.ts
@@ -37,13 +37,7 @@ import ensureError from '../utils/ensureError';
  *  }, null);
  * ```
  */
-function usePromise<T>(
-  factory: () => Promise<T>,
-  fallbackValue: T,
-  options?: {
-    enabled?: boolean;
-  },
-) {
+function usePromise<T>(factory: () => Promise<T>, fallbackValue: T) {
   const [result, setResult] = useState<T>(fallbackValue);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -56,10 +50,6 @@ function usePromise<T>(
     // `isMounted` prevents updates after component unmount,
     // `isSubscribed` allows proper cleanup if the effect re-runs before the promise resolves.
     if (!isMounted.current) {
-      return;
-    }
-
-    if (options?.enabled === false) {
       return;
     }
 
@@ -88,7 +78,7 @@ function usePromise<T>(
 
         setIsLoading(false);
       });
-  }, [factory, isMounted, options?.enabled]);
+  }, [factory, isMounted]);
 
   // Initial fetch & automatically refetch when the factory function changes.
   useEffect(() => {

--- a/libs/tangle-shared-ui/src/hooks/usePromise.ts
+++ b/libs/tangle-shared-ui/src/hooks/usePromise.ts
@@ -45,7 +45,7 @@ function usePromise<T>(
   },
 ) {
   const [result, setResult] = useState<T>(fallbackValue);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const isMounted = useIsMountedRef();
   const isSubscribed = useRef(true);

--- a/libs/tangle-shared-ui/src/types/error.ts
+++ b/libs/tangle-shared-ui/src/types/error.ts
@@ -1,11 +1,13 @@
 export enum TangleErrorCode {
   FEATURE_NOT_SUPPORTED,
   NO_ACTIVE_ACCOUNT,
+  INVALID_PARAMS,
 }
 
 export const TangleErrorTitleMap: Record<TangleErrorCode, string> = {
   [TangleErrorCode.FEATURE_NOT_SUPPORTED]: 'Feature Not Supported',
   [TangleErrorCode.NO_ACTIVE_ACCOUNT]: 'No Active Account',
+  [TangleErrorCode.INVALID_PARAMS]: 'Invalid Params',
 };
 
 export const TangleErrorDescriptionMap: Record<TangleErrorCode, string> = {
@@ -13,6 +15,8 @@ export const TangleErrorDescriptionMap: Record<TangleErrorCode, string> = {
     'The requested feature is not supported by the current API. Please try refreshing the page or switching to a different API endpoint. If the issue persists, the feature may not be available in this version of the application.',
   [TangleErrorCode.NO_ACTIVE_ACCOUNT]:
     'No active account found. Please connect a wallet and try again.',
+  [TangleErrorCode.INVALID_PARAMS]:
+    'The parameters passed to the function are invalid.',
 };
 
 export class TangleError extends Error {


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- `usePromies`' `isLoading` should default to `false`.
- Reset `result` in `useApiRx` on RPC change.
- Data hooks should return errors for invalid arguments.
- Vault table should use `isLoading` prop for loading state, not `data`.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes `NaN`.