### PR TITLE
ci(tools): Add Netlify Build Ignore to Improve Release Process

### DIFF
--- a/apps/tangle-cloud/netlify.toml
+++ b/apps/tangle-cloud/netlify.toml
@@ -1,9 +1,9 @@
 [build]
-  publish = "dist/apps/tangle-dapp"
-  command = "yarn nx build tangle-dapp"
+  publish = "dist/apps/tangle-cloud"
+  command = "yarn nx build tangle-cloud"
 
   # If the branch is not master, continue the build process
   # If the branch is master, check if the project's CHANGELOG.md file has changed
   # If the CHANGELOG.md file has changed, continue the build process,
   # Otherwise, stop the build process
-  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-dapp/CHANGELOG.md && exit 0 || exit 1"
+  ignore = "[ \"$BRANCH\" != \"master\" ] && exit 1 || git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/tangle-cloud/CHANGELOG.md && exit 0 || exit 1"


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- Improve the release process by adding a Netlify build ignore.

	- 🚩 Currently, merging `develop` into `master` triggers a full monorepo redeploy in Netlify, even though only the released dApp should be updated.

	- 💡 The solution is to configure Netlify build ignore for each dApp, so it only redeploys on `master` if changes are detected within the dApp's `CHANGLOG.md` file.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [x] `apps/tangle-dapp`
- [x] `apps/tangle-cloud`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes `NaN`.