### PR TITLE
feat(tangle-dapp): Create restaking & services setup scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @AtelyPham @devpavan04 @yuri-xyz @monaiuu @danielbui12
+*       @AtelyPham @devpavan04 @yuri-xyz @danielbui12

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "codegen": "graphql-codegen --config codegen.ts",
     "check:codegen": "node ./tools/checkCodegen.js",
     "scan": "react-scan",
-    "postinstall": "husky"
+    "postinstall": "husky",
+    "script:setupServices": "bun scripts/setupServices.ts",
+    "script:setupRestaking": "bun scripts/setupRestaking.ts"
   },
   "resolutions": {
     "@polkadot/api": "^13.2.1",

--- a/scripts/setupRestaking.ts
+++ b/scripts/setupRestaking.ts
@@ -1,0 +1,57 @@
+import { ALICE, CHARLIE, createAmount, createApi, submitTx } from './util';
+
+const PALLET_ACCOUNT_ADDRESS =
+  '5EYCAe5cKPAoFh2HnQQvpKqRYZGqBpaA87u4Zzw89qPE58is';
+
+const LST_AND_ASSET_AND_VAULT_ID = 1;
+
+(async () => {
+  const api = await createApi();
+
+  // 1. Fund pallet account, otherwise restaking actions will fail with `Token.CannotCreate`.
+  await submitTx({
+    description: 'fund pallet account',
+    tx: api.tx.balances.transferAllowDeath(
+      PALLET_ACCOUNT_ADDRESS,
+      createAmount(10),
+    ),
+  });
+
+  // 2. Create an LST which will create a corresponding custom asset with the same ID.
+  await submitTx({
+    description: 'create LST & asset',
+    tx: api.tx.lst.create(
+      createAmount(100),
+      ALICE.address,
+      ALICE.address,
+      ALICE.address,
+      null,
+      null,
+    ),
+  });
+
+  // 3. Create a vault for the new asset by creating its reward config.
+  const createVaultRewardConfigTx = api.tx.rewards.createRewardVault(
+    LST_AND_ASSET_AND_VAULT_ID,
+    {
+      apy: 1,
+      incentiveCap: createAmount(60_000),
+      depositCap: createAmount(60_000),
+    },
+  );
+
+  await submitTx({
+    description: 'create vault reward config',
+    tx: createVaultRewardConfigTx,
+    useSudo: true,
+  });
+
+  // 4. Join operators for CHARLIE (required for delegation step).
+  await submitTx({
+    description: 'join operators',
+    origin: CHARLIE,
+    tx: api.tx.multiAssetDelegation.joinOperators(createAmount(100)),
+  });
+
+  api.disconnect();
+})();

--- a/scripts/setupRestaking.ts
+++ b/scripts/setupRestaking.ts
@@ -1,4 +1,11 @@
-import { ALICE, CHARLIE, createAmount, createApi, submitTx } from './util';
+import {
+  ALICE,
+  CHARLIE,
+  createAmount,
+  createApi,
+  getRandomShortId,
+  submitTx,
+} from './util';
 
 const PALLET_ACCOUNT_ADDRESS =
   '5EYCAe5cKPAoFh2HnQQvpKqRYZGqBpaA87u4Zzw89qPE58is';
@@ -25,7 +32,7 @@ const LST_AND_ASSET_AND_VAULT_ID = 1;
       ALICE.address,
       ALICE.address,
       ALICE.address,
-      null,
+      `LST ${getRandomShortId()}`,
       null,
     ),
   });

--- a/scripts/setupRestaking.ts
+++ b/scripts/setupRestaking.ts
@@ -53,5 +53,5 @@ const LST_AND_ASSET_AND_VAULT_ID = 1;
     tx: api.tx.multiAssetDelegation.joinOperators(createAmount(100)),
   });
 
-  api.disconnect();
+  await api.disconnect();
 })();

--- a/scripts/setupServices.ts
+++ b/scripts/setupServices.ts
@@ -1,0 +1,13 @@
+import { createApi, submitTx } from './util';
+
+(async () => {
+  const api = await createApi();
+
+  const createBlueprint = async () => {
+    const tx = api.tx.staking.bondExtra(BigInt('1000000000000000000'));
+
+    await submitTx('create blueprint', tx);
+  };
+
+  await createBlueprint();
+})();

--- a/scripts/setupServices.ts
+++ b/scripts/setupServices.ts
@@ -1,13 +1,40 @@
-import { createApi, submitTx } from './util';
+import { createApi, getRandomShortId, submitTx } from './util';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const BLUEPRINTS_COUNT = 10;
 
 (async () => {
   const api = await createApi();
 
-  const createBlueprint = async () => {
-    const tx = api.tx.staking.bondExtra(BigInt('1000000000000000000'));
+  // 1. Setup blueprint service manager. This is required to create blueprints.
+  await submitTx({
+    description: 'setup blueprint service manager',
+    tx: api.tx.services.updateMasterBlueprintServiceManager(ZERO_ADDRESS),
+    useSudo: true,
+  });
 
-    await submitTx('create blueprint', tx);
+  const createBlueprint = () => {
+    const id = getRandomShortId();
+
+    return api.tx.services.createBlueprint({
+      metadata: {
+        name: `blueprint ${id}`,
+        description: 'This is a test blueprint.',
+        author: 'Tangle Network',
+        category: 'test',
+        license: 'MIT',
+      },
+    });
   };
 
-  await createBlueprint();
+  // 2. Create blueprints in a batch.
+  await submitTx({
+    description: 'create blueprints',
+    tx: api.tx.utility.batch(
+      Array.from({ length: BLUEPRINTS_COUNT }, createBlueprint),
+    ),
+  });
+
+  await api.disconnect();
 })();

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -62,7 +62,7 @@ export const submitTx = async ({
   useSudo = false,
 }: SubmitTxOptions) => {
   // Use a random ID to identify the transaction in the logs.
-  const randomId = Math.random().toString(36).substring(2, 8);
+  const randomId = getRandomShortId();
 
   console.log(`${randomId} ${description}: submitting...`);
 
@@ -121,4 +121,8 @@ const extractErrorFromTxStatus = (status: ISubmittableResult): Error | null => {
   return new Error(
     `${status.dispatchError.type}.${status.dispatchError.value.toString()}`,
   );
+};
+
+export const getRandomShortId = (): string => {
+  return Math.random().toString(36).substring(2, 8);
 };

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,0 +1,124 @@
+import { ApiPromise, Keyring, WsProvider } from '@polkadot/api';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+
+// Wait for the crypto library to be ready globally for this module.
+await cryptoWaitReady();
+
+export const ALICE = new Keyring({ type: 'sr25519' }).addFromUri('//Alice');
+
+export const BOB = new Keyring({ type: 'sr25519' }).addFromUri('//Bob');
+
+export const CHARLIE = new Keyring({ type: 'sr25519' }).addFromUri('//Charlie');
+
+export const TANGLE_LOCAL_RPC_URL = 'ws://127.0.0.1:9944';
+
+export const TANGLE_LOCAL_DECIMALS = 18;
+
+let isCreatingApi = false;
+let apiCache: ApiPromise | null = null;
+
+export const createApi = async () => {
+  if (apiCache !== null) {
+    return apiCache;
+  } else if (isCreatingApi) {
+    throw new Error('Api is being created; you have a race condition');
+  }
+
+  isCreatingApi = true;
+
+  console.log(
+    'note: these scripts are meant to be run against a local node, also ensure that the chain is re-started to a fresh state before running setup scripts\n',
+  );
+
+  return new Promise<ApiPromise>((resolve) => {
+    const api = new ApiPromise({
+      provider: new WsProvider(TANGLE_LOCAL_RPC_URL),
+      noInitWarn: true,
+    });
+
+    api.once('ready', () => {
+      console.log('api is ready');
+      isCreatingApi = false;
+      apiCache = api;
+      resolve(api);
+    });
+  });
+};
+
+type SubmitTxOptions = {
+  description: string;
+  tx: SubmittableExtrinsic<'promise', ISubmittableResult>;
+  origin?: KeyringPair;
+  useSudo?: boolean;
+};
+
+export const submitTx = async ({
+  description,
+  tx,
+  origin = ALICE,
+  useSudo = false,
+}: SubmitTxOptions) => {
+  // Use a random ID to identify the transaction in the logs.
+  const randomId = Math.random().toString(36).substring(2, 8);
+
+  console.log(`${randomId} ${description}: submitting...`);
+
+  const api = await createApi();
+  const finalTx = useSudo ? api.tx.sudo.sudo(tx) : tx;
+
+  return new Promise<void>((resolve, reject) => {
+    finalTx.signAndSend(useSudo ? ALICE : origin, (status) => {
+      const error = extractErrorFromTxStatus(status);
+
+      if (error !== null) {
+        console.error(`${randomId} ${description}: error: ${error}`);
+        reject(error);
+      } else if (status.isInBlock) {
+        console.log(`${randomId} ${description}: in block`);
+      } else if (status.isFinalized) {
+        console.log(`${randomId} ${description}: finalized`);
+        resolve();
+      }
+    });
+  });
+};
+
+export const createAmount = (amount: number): bigint => {
+  // Scale the amount by 10^decimals to match the precision in planks.
+  return BigInt(amount) * BigInt(10 ** TANGLE_LOCAL_DECIMALS);
+};
+
+const ensureError = (possibleError: unknown): Error => {
+  if (possibleError instanceof Error) {
+    return possibleError;
+  }
+
+  return new Error(`Unknown error: ${possibleError}`);
+};
+
+const extractErrorFromTxStatus = (status: ISubmittableResult): Error | null => {
+  if (
+    !status.isError &&
+    !status.isWarning &&
+    status.dispatchError === undefined
+  ) {
+    return null;
+  } else if (status.dispatchError === undefined) {
+    return ensureError(status.internalError);
+  }
+
+  if (status.dispatchError.isModule) {
+    const metaError = status.dispatchError.registry.findMetaError(
+      status.dispatchError.asModule,
+    );
+
+    return new Error(`Dispatch error: ${metaError.section}.${metaError.name}`);
+  }
+
+  return new Error(
+    `${status.dispatchError.type}.${status.dispatchError.value.toString()}`,
+  );
+};


### PR DESCRIPTION
## Summary of changes

_Provide a detailed description of proposed changes._

- ➕ Created a script to easily setup a testing environment for local dev when testing restaking actions (deposit, delegate, etc.). This is useful because it automates the need to manually setup a test env every time a local node is restarted.
- ➕ Created a similar script but for setting up blueprints & services for testing. This is mainly useful for Tangle Cloud.

**Note**: Running these scripts requires [Bun](https://bun.sh/). I think this is a good idea to avoid having to compile the TypeScript files -- or worse yet, having them be in JS. Here's how you might run the scripts after you've installed Bun:
```sh
yarn script:setupRestaking # create LST & prepare for restaking actions
yarn script:setupServices # create blueprints
```

We can also follow this structure of scripts going forward:
- Placing them under `scripts/`.
- Utilizing the `util.ts` file to write helper functions.
- Registering them as `yarn script:x`.

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `apps/leaderboard`
- [ ] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Associated issue(s)

_Specify any issues that can be closed from these changes (e.g. `Closes #233`)._

- Closes #2985

### Screen Recording

_If possible provide screenshots and/or a screen recording of proposed change._

![CleanShot 2025-04-18 at 20 31 21](https://github.com/user-attachments/assets/66b772bc-144a-4a7c-b221-96c8d46187f6)