### PR TITLE
fix(tangle-dapp): Fixes empty operators list in restake page

### DIFF
--- a/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
@@ -37,7 +37,7 @@ export const InstructionCard: FC<InstructionCardProps> = ({ rootProps }) => {
                     <Typography
                       variant="body1"
                       fw="bold"
-                      className="!text-blue-50"
+                      className="text-blue-60 dark:text-blue-40"
                     >
                       {instruction.title}
                     </Typography>

--- a/apps/tangle-dapp/src/containers/restaking/OperatorsTable.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/OperatorsTable.tsx
@@ -41,6 +41,7 @@ type Props = {
   operatorMap: OperatorMap;
   operatorTvl?: OperatorTvlGroup['operatorTvl'];
   onRestakeClicked?: LinkProps['onClick'];
+  isLoading?: boolean;
 };
 
 const OperatorsTable: FC<Props> = ({
@@ -48,6 +49,7 @@ const OperatorsTable: FC<Props> = ({
   operatorMap,
   operatorTvl,
   onRestakeClicked,
+  isLoading,
 }) => {
   const [globalFilter, setGlobalFilter] = useState('');
 
@@ -71,7 +73,7 @@ const OperatorsTable: FC<Props> = ({
 
   const operators = useMemo(
     () =>
-      Object.entries(operatorMap).map<OperatorUI>(
+      Array.from(operatorMap.entries()).map<OperatorUI>(
         ([addressString, { delegations, restakersCount, stake }]) => {
           const address = assertSubstrateAddress(addressString);
           const tvlInUsd = operatorTvl?.get(address) ?? null;
@@ -168,6 +170,7 @@ const OperatorsTable: FC<Props> = ({
           onGlobalFilterChange={setGlobalFilter}
           data={operators}
           RestakeOperatorAction={RestakeAction}
+          isLoading={isLoading}
         />
 
         <JoinOperatorsModal setIsOpen={setIsJoinOperatorsModalOpen} />

--- a/apps/tangle-dapp/src/containers/restaking/RestakeTabContent.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/RestakeTabContent.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, type FC } from 'react';
+import { ReactNode, useCallback, useEffect, type FC } from 'react';
 import RestakeTabs from '../../pages/restake/RestakeTabs';
 import { RestakeAction, RestakeTab } from '../../constants';
 import DepositForm from '../../pages/restake/deposit/DepositForm';
@@ -30,7 +30,7 @@ type Props = {
 
 const RestakeTabContent: FC<Props> = ({ tab }) => {
   const { result: delegatorInfo } = useRestakeDelegatorInfo();
-  const { result: operatorMap } = useRestakeOperatorMap();
+  const { result: operatorMap, isLoading: isLoadingOperators, error: operatorMapError } = useRestakeOperatorMap();
   const { operatorConcentration, operatorTvl } = useRestakeTvl(delegatorInfo);
   const navigate = useNavigate();
 
@@ -43,6 +43,12 @@ const RestakeTabContent: FC<Props> = ({ tab }) => {
   const handleRestakeClicked = useCallback(() => {
     navigate(PagePath.RESTAKE_DEPOSIT);
   }, [navigate]);
+
+  useEffect(() => {
+    if (operatorMapError) {
+      console.error('Error fetching operator map:', operatorMapError);
+    }
+  }, [operatorMapError]);
 
   const getRestakeTabContent = (action: RestakeTabOrAction): ReactNode => {
     switch (action) {
@@ -71,6 +77,7 @@ const RestakeTabContent: FC<Props> = ({ tab }) => {
             operatorMap={operatorMap}
             operatorTvl={operatorTvl}
             onRestakeClicked={handleRestakeClicked}
+            isLoading={isLoadingOperators}
           />
         );
       case RestakeTab.BLUEPRINTS:

--- a/apps/tangle-dapp/src/containers/restaking/RestakeTabContent.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/RestakeTabContent.tsx
@@ -30,7 +30,11 @@ type Props = {
 
 const RestakeTabContent: FC<Props> = ({ tab }) => {
   const { result: delegatorInfo } = useRestakeDelegatorInfo();
-  const { result: operatorMap, isLoading: isLoadingOperators, error: operatorMapError } = useRestakeOperatorMap();
+  const {
+    result: operatorMap,
+    isLoading: isLoadingOperators,
+    error: operatorMapError,
+  } = useRestakeOperatorMap();
   const { operatorConcentration, operatorTvl } = useRestakeTvl(delegatorInfo);
   const navigate = useNavigate();
 

--- a/apps/tangle-dapp/src/pages/restake/delegate/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/delegate/index.tsx
@@ -295,7 +295,7 @@ const RestakeDelegateForm: FC<Props> = ({ assets }) => {
 
   const operators = useMemo<RestakeOperator[]>(() => {
     return (
-      Object.entries(operatorMap)
+      Array.from(operatorMap.entries())
         // Include only active operators.
         .filter(([, metadata]) => metadata.status === 'Active')
         .map(([accountId]) => ({

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeOperatorMap.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeOperatorMap.ts
@@ -24,31 +24,37 @@ const useRestakeOperatorMap = () => {
       return apiRx.query.multiAssetDelegation.operators.entries().pipe(
         map((entries) => {
           return entries.reduce(
-            (operatorsMap, [accountStorage, operatorMetadata]) => {
+            (operatorsMap, [accountStorage, operatorMetadata], _index) => {
+              const accountId = accountStorage.args[0];
+              const accountIdStr = accountId.toString();
+
               if (operatorMetadata.isNone) {
                 return operatorsMap;
               }
 
-              const accountId = accountStorage.args[0];
               const operator = operatorMetadata.unwrap();
 
-              const { delegations, restakersCount } = toPrimitiveDelegations(
-                operator.delegations,
-              );
+              try {
+                const { delegations, restakersCount } = toPrimitiveDelegations(
+                  operator.delegations,
+                );
 
-              const operatorMetadataPrimitive = {
-                stake: operator.stake.toBigInt(),
-                delegationCount: operator.delegationCount.toNumber(),
-                bondLessRequest: toPrimitiveRequest(operator.request),
-                delegations,
-                restakersCount,
-                status: toPrimitiveStatus(operator.status),
-              } satisfies OperatorMetadata;
+                const operatorMetadataPrimitive = {
+                  stake: operator.stake.toBigInt(),
+                  delegationCount: operator.delegationCount.toNumber(),
+                  bondLessRequest: toPrimitiveRequest(operator.request),
+                  delegations,
+                  restakersCount,
+                  status: toPrimitiveStatus(operator.status),
+                } satisfies OperatorMetadata;
 
-              operatorsMap.set(
-                assertSubstrateAddress(accountId.toString()),
-                operatorMetadataPrimitive,
-              );
+                operatorsMap.set(
+                  assertSubstrateAddress(accountIdStr),
+                  operatorMetadataPrimitive,
+                );
+              } catch (e) {
+                console.error(`Error processing operator ${accountIdStr}:`, e);
+              }
 
               return operatorsMap;
             },


### PR DESCRIPTION
## Summary of changes

- `tangle-dapp`: fixes empty operators list in restake page and select operator modal of delegate restake action
- `tangle-cloud`: fixes instruction component colors in light/dark mode

### Proposed area of change

- [x] `apps/tangle-dapp`
- [x] `apps/tangle-cloud`
- [ ] `apps/leaderboard`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Screen Recording

https://github.com/user-attachments/assets/08258321-8a42-4618-8d38-01f44fc264dd