### PR TITLE
Fix long account name layout

### DIFF
--- a/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
+++ b/libs/tangle-shared-ui/src/components/ConnectWalletButton/WalletDropdown.tsx
@@ -104,7 +104,11 @@ const WalletDropdown: FC<{
             {wallet.Logo}
 
             <div>
-              <Typography variant="h5" fw="bold" className="capitalize">
+              <Typography
+                variant="h5"
+                fw="bold"
+                className="capitalize truncate max-w-[200px]"
+              >
                 {accountName ?? wallet.name}
               </Typography>
 


### PR DESCRIPTION
## Summary
- ensure account name truncation in wallet dropdown header

## Testing
- `npx nx run tangle-shared-ui:lint` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx nx run tangle-shared-ui:test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685bc67a221c833089c3a4b872efa158