### PR TITLE
fix(tangle-cloud): UI/UX Fixes & Improvements

### DIFF
--- a/apps/tangle-cloud/src/components/TangleCloudCard.tsx
+++ b/apps/tangle-cloud/src/components/TangleCloudCard.tsx
@@ -9,8 +9,10 @@ const TangleCloudCard: FC<TangleCloudCardProps> = ({ children, className }) => {
     <Card
       variant={CardVariant.GLASS}
       className={twMerge(
-        'relative overflow-hidden shadow-sm',
-        'w-full xl:w-1/2 p-5 z-0',
+        'relative overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300',
+        'w-full xl:w-1/2 p-6 z-0',
+        'border border-mono-40 dark:border-mono-160',
+        'backdrop-blur-sm',
         className,
       )}
     >
@@ -21,10 +23,12 @@ const TangleCloudCard: FC<TangleCloudCardProps> = ({ children, className }) => {
           'absolute top-0 left-0 w-full h-full z-0',
           "dark:bg-[url('/static/assets/accounts/grid-bg-colored.svg')]",
           'bg-cover bg-center bg-no-repeat',
-          'bg-gradient-to-b from-mono-0.7 to-transparent',
-          'shadow-[0px_4px_8px_0px_rgba(0,0,0,0.08)]',
-          'dark:shadow-[0px_4px_8px_0px_rgba(0,0,0,0.20)]',
-          'dark:bg-blend-lighten',
+          'bg-gradient-to-br from-blue-5 via-mono-10 to-purple-5',
+          'dark:bg-gradient-to-br dark:from-blue-180 dark:via-mono-180 dark:to-purple-180',
+          'opacity-60 dark:opacity-40',
+          'shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
+          'dark:shadow-[0px_8px_24px_0px_rgba(0,0,0,0.40)]',
+          'dark:bg-blend-overlay',
         )}
       />
     </Card>

--- a/apps/tangle-cloud/src/components/accountStatsCard/AccountStatsCardBody.tsx
+++ b/apps/tangle-cloud/src/components/accountStatsCard/AccountStatsCardBody.tsx
@@ -17,7 +17,7 @@ export const AccountStatsCardBody: FC<AccountStatsCardBodyProps> = ({
           const item = statsItems[index];
           const isLeftColumn = index % 2 === 0;
           const isTopRow = index < 2;
-          
+
           return item ? (
             <StatsItem
               key={index}

--- a/apps/tangle-cloud/src/components/accountStatsCard/AccountStatsCardBody.tsx
+++ b/apps/tangle-cloud/src/components/accountStatsCard/AccountStatsCardBody.tsx
@@ -1,4 +1,4 @@
-import { Children, type FC } from 'react';
+import { type FC } from 'react';
 import { Socials, StatsItem } from '@tangle-network/ui-components';
 import { AccountStatsCardBodyProps } from '.';
 import cx from 'classnames';
@@ -12,22 +12,36 @@ export const AccountStatsCardBody: FC<AccountStatsCardBodyProps> = ({
 }) => {
   return (
     <div {...props} className="w-full space-y-5">
-      <div className="grid grid-cols-2">
-        {Children.toArray(
-          statsItems.map((item, index) => (
+      <div className="grid grid-cols-2 grid-rows-2 min-h-[120px]">
+        {Array.from({ length: 4 }).map((_, index) => {
+          const item = statsItems[index];
+          const isLeftColumn = index % 2 === 0;
+          const isTopRow = index < 2;
+          
+          return item ? (
             <StatsItem
+              key={index}
               className={cx('gap-0 border-mono-100 dark:border-mono-140 p-2', {
-                'border-r': index % 2 === 0,
-                'border-b': index < statsItems.length - 2,
-                'pl-5': index % 2 === 1,
+                'border-r': isLeftColumn,
+                'border-b': isTopRow,
+                'pl-5': !isLeftColumn,
               })}
               title={item.title}
               tooltip={item.tooltip}
             >
               {item.children}
             </StatsItem>
-          )),
-        )}
+          ) : (
+            <div
+              key={`placeholder-${index}`}
+              className={cx('border-mono-100 dark:border-mono-140 p-2', {
+                'border-r': isLeftColumn,
+                'border-b': isTopRow,
+                'pl-5': !isLeftColumn,
+              })}
+            />
+          );
+        })}
       </div>
 
       <Socials

--- a/apps/tangle-cloud/src/data/operators/useOperatorStatsData.ts
+++ b/apps/tangle-cloud/src/data/operators/useOperatorStatsData.ts
@@ -29,6 +29,7 @@ const operatorStatsSchema = z.object({
 
 export const useOperatorStatsData = (
   operatorAddress: SubstrateAddress | null | undefined,
+  refreshTrigger?: number,
 ) => {
   const { network } = useNetworkStore();
 
@@ -162,7 +163,6 @@ export const useOperatorStatsData = (
                 }),
               );
 
-        // TODO: after the instance is terminated, this will be removed. using Graphql to get the deployed services
         const deployedServices$ =
           apiRx.query.services?.instances === undefined
             ? of({})
@@ -213,7 +213,8 @@ export const useOperatorStatsData = (
           ),
         );
       },
-      [operatorAddress, network.ss58Prefix],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [operatorAddress, network.ss58Prefix, refreshTrigger],
     ),
   );
 

--- a/apps/tangle-cloud/src/data/operators/useUserStatsData.ts
+++ b/apps/tangle-cloud/src/data/operators/useUserStatsData.ts
@@ -16,7 +16,10 @@ const userStatsSchema = z.object({
   consumedServices: z.number().default(0),
 });
 
-export const useUserStatsData = (accountAddress: string | null | undefined) => {
+export const useUserStatsData = (
+  accountAddress: string | null | undefined,
+  refreshTrigger?: number,
+) => {
   const { result: userStats, ...rest } = useApiRx(
     useCallback(
       (apiRx) => {
@@ -221,7 +224,8 @@ export const useUserStatsData = (accountAddress: string | null | undefined) => {
           }),
         );
       },
-      [accountAddress],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [accountAddress, refreshTrigger],
     ),
   );
 

--- a/apps/tangle-cloud/src/data/services/useUserOwnedInstances.ts
+++ b/apps/tangle-cloud/src/data/services/useUserOwnedInstances.ts
@@ -16,6 +16,7 @@ import { encodeAddress, decodeAddress } from '@polkadot/util-crypto';
 
 export const useUserOwnedInstances = (
   userAddress: SubstrateAddress | null | undefined,
+  refreshTrigger?: number,
 ) => {
   const { result: userOwnedData, ...rest } = useApiRx(
     useCallback(
@@ -163,7 +164,8 @@ export const useUserOwnedInstances = (
           }),
         );
       },
-      [userAddress],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [userAddress, refreshTrigger],
     ),
   );
 

--- a/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
+++ b/apps/tangle-cloud/src/pages/blueprints/[id]/page.tsx
@@ -62,10 +62,6 @@ const Page = () => {
       <div className="space-y-5">
         <SkeletonLoader className="min-h-64" />
 
-        <Typography variant="h4" fw="bold">
-          Operators running
-        </Typography>
-
         <SkeletonLoader className="min-h-52" />
       </div>
     );
@@ -111,13 +107,16 @@ const Page = () => {
       />
 
       <div className="space-y-5">
-        <Typography variant="h4" fw="bold">
-          Registered Operators
-        </Typography>
+        {!isLoading && (
+          <Typography variant="h4" fw="bold">
+            Registered Operators
+          </Typography>
+        )}
 
         <OperatorsTable
           RestakeOperatorAction={RestakeOperatorAction}
           data={result.operators}
+          isLoading={isLoading}
         />
       </div>
 

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -138,36 +138,37 @@ export const AccountStatsCard: FC<
       operatorStatsData && operatorStatsData.registeredBlueprints > 0;
     const isActiveOperator = isOperator && hasOperatorData;
 
-    return [
-      {
-        title: 'Registered Blueprints',
-        children: isActiveOperator ? operatorStatsData.registeredBlueprints : 0,
-        tooltip: 'Number of blueprints you have registered as an operator',
-      },
-      {
-        title: 'Running Services',
-        children: isActiveOperator
-          ? operatorStatsData.runningServices
-          : userStatsData.runningServices,
-        tooltip: isActiveOperator
-          ? 'Services currently running that you operate as an operator'
-          : 'Services currently running that you have deployed',
-      },
-      {
-        title: 'Pending Services',
-        children: isActiveOperator
-          ? operatorStatsData.pendingServices
-          : userStatsData.pendingServices,
-        tooltip: isActiveOperator
-          ? 'Service requests pending your approval/rejection as an operator'
-          : 'Service requests you have submitted that are pending operator approval',
-      },
-      {
-        title: 'Deployed Services',
-        children: userStatsData.deployedServices,
-        tooltip: 'Total services you have deployed as a user/deployer',
-      },
-    ];
+    const items = [];
+
+    // Only show operator-specific stats if user is an operator with registered blueprints
+    if (isActiveOperator) {
+      items.push(
+        {
+          title: 'Registered Blueprints',
+          children: operatorStatsData.registeredBlueprints,
+          tooltip: 'Number of blueprints you have registered as an operator',
+        },
+        {
+          title: 'Running Services',
+          children: operatorStatsData.runningServices,
+          tooltip: 'Services currently running that you operate as an operator',
+        },
+        {
+          title: 'Pending Services',
+          children: operatorStatsData.pendingServices,
+          tooltip: 'Service requests pending your approval/rejection as an operator',
+        },
+      );
+    }
+
+    // Always show deployed services for all users
+    items.push({
+      title: 'Deployed Services',
+      children: userStatsData.deployedServices,
+      tooltip: 'Total services you have deployed as a user/deployer',
+    });
+
+    return items;
   }, [operatorStatsData, userStatsData, isOperator]);
 
   return (

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -157,7 +157,8 @@ export const AccountStatsCard: FC<
         {
           title: 'Pending Services',
           children: operatorStatsData.pendingServices,
-          tooltip: 'Service requests pending your approval/rejection as an operator',
+          tooltip:
+            'Service requests pending your approval/rejection as an operator',
         },
       );
     }
@@ -184,10 +185,7 @@ export const AccountStatsCard: FC<
         title={identityName}
         RightElement={
           isOperator ? (
-            <Chip
-              color="blue"
-              className="text-xs px-2 py-1"
-            >
+            <Chip color="blue" className="text-xs px-2 py-1">
               Operator
             </Chip>
           ) : undefined

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -21,7 +21,10 @@ import useOperatorInfo from '@tangle-network/tangle-shared-ui/hooks/useOperatorI
 import { useOperatorStatsData } from '../../data/operators/useOperatorStatsData';
 import { useUserStatsData } from '../../data/operators/useUserStatsData';
 
-export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
+export const AccountStatsCard: FC<
+  AccountStatsCardProps & { refreshTrigger?: number }
+> = (props) => {
+  const { refreshTrigger, ...cardProps } = props;
   const accountAddress = useActiveAccountAddress();
   const { isOperator } = useOperatorInfo();
   const rpcEndpoints = useNetworkStore((store) => store.network.wsRpcEndpoints);
@@ -39,6 +42,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
 
       return accountAddress;
     }, [accountAddress, isOperator]),
+    refreshTrigger,
   );
 
   const { result: userStatsData } = useUserStatsData(
@@ -49,6 +53,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
 
       return accountAddress;
     }, [accountAddress]),
+    refreshTrigger,
   );
 
   const { data: accountInfo } = useSWRImmutable(
@@ -166,7 +171,7 @@ export const AccountStatsCard: FC<AccountStatsCardProps> = (props) => {
   }, [operatorStatsData, userStatsData, isOperator]);
 
   return (
-    <AccountStatsDetailCard.Root {...props.rootProps}>
+    <AccountStatsDetailCard.Root {...cardProps.rootProps}>
       <AccountStatsDetailCard.Header
         IconElement={
           <Avatar

--- a/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/AccountStatsCard.tsx
@@ -7,6 +7,7 @@ import {
   isSubstrateAddress,
   KeyValueWithButton,
   shortenString,
+  Chip,
 } from '@tangle-network/ui-components';
 import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetworkStore';
 import useSWRImmutable from 'swr/immutable';
@@ -170,7 +171,6 @@ export const AccountStatsCard: FC<
 
     return items;
   }, [operatorStatsData, userStatsData, isOperator]);
-
   return (
     <AccountStatsDetailCard.Root {...cardProps.rootProps}>
       <AccountStatsDetailCard.Header
@@ -182,6 +182,16 @@ export const AccountStatsCard: FC<
           />
         }
         title={identityName}
+        RightElement={
+          isOperator ? (
+            <Chip
+              color="blue"
+              className="text-xs px-2 py-1"
+            >
+              Operator
+            </Chip>
+          ) : undefined
+        }
         description={
           <KeyValueWithButton
             size="sm"

--- a/apps/tangle-cloud/src/pages/instances/BlueprintManagementSection.tsx
+++ b/apps/tangle-cloud/src/pages/instances/BlueprintManagementSection.tsx
@@ -1,7 +1,10 @@
 import { RegisteredBlueprintsTabs } from './RegisteredBlueprints';
 import { InstancesTabs } from './Instances';
-import { FC, Dispatch, SetStateAction } from 'react';
+import { FC, Dispatch, SetStateAction, useMemo } from 'react';
 import useOperatorInfo from '@tangle-network/tangle-shared-ui/hooks/useOperatorInfo';
+import { useOperatorStatsData } from '../../data/operators/useOperatorStatsData';
+import useActiveAccountAddress from '@tangle-network/tangle-shared-ui/hooks/useActiveAccountAddress';
+import { isSubstrateAddress } from '@tangle-network/ui-components';
 
 interface BlueprintManagementSectionProps {
   refreshTrigger: number;
@@ -12,10 +15,32 @@ export const BlueprintManagementSection: FC<
   BlueprintManagementSectionProps
 > = ({ refreshTrigger, setRefreshTrigger }) => {
   const { isOperator } = useOperatorInfo();
+  const accountAddress = useActiveAccountAddress();
+
+  const { result: operatorStatsData } = useOperatorStatsData(
+    useMemo(() => {
+      if (
+        !accountAddress ||
+        !isOperator ||
+        !isSubstrateAddress(accountAddress)
+      ) {
+        return null;
+      }
+
+      return accountAddress;
+    }, [accountAddress, isOperator]),
+    refreshTrigger,
+  );
+
+  const hasRegisteredBlueprints = useMemo(() => {
+    return operatorStatsData && operatorStatsData.registeredBlueprints > 0;
+  }, [operatorStatsData]);
+
+  const shouldShowRegisteredBlueprints = isOperator && hasRegisteredBlueprints;
 
   return (
     <>
-      {isOperator && <RegisteredBlueprintsTabs />}
+      {shouldShowRegisteredBlueprints && <RegisteredBlueprintsTabs />}
       <InstancesTabs
         refreshTrigger={refreshTrigger}
         setRefreshTrigger={setRefreshTrigger}

--- a/apps/tangle-cloud/src/pages/instances/BlueprintManagementSection.tsx
+++ b/apps/tangle-cloud/src/pages/instances/BlueprintManagementSection.tsx
@@ -1,15 +1,25 @@
 import { RegisteredBlueprintsTabs } from './RegisteredBlueprints';
 import { InstancesTabs } from './Instances';
-import { FC } from 'react';
+import { FC, Dispatch, SetStateAction } from 'react';
 import useOperatorInfo from '@tangle-network/tangle-shared-ui/hooks/useOperatorInfo';
 
-export const BlueprintManagementSection: FC = () => {
+interface BlueprintManagementSectionProps {
+  refreshTrigger: number;
+  setRefreshTrigger: Dispatch<SetStateAction<number>>;
+}
+
+export const BlueprintManagementSection: FC<
+  BlueprintManagementSectionProps
+> = ({ refreshTrigger, setRefreshTrigger }) => {
   const { isOperator } = useOperatorInfo();
 
   return (
     <>
       {isOperator && <RegisteredBlueprintsTabs />}
-      <InstancesTabs />
+      <InstancesTabs
+        refreshTrigger={refreshTrigger}
+        setRefreshTrigger={setRefreshTrigger}
+      />
     </>
   );
 };

--- a/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
@@ -179,12 +179,12 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
         enableSorting: false,
         cell: (props) => {
           return (
-            <TableCellWrapper className="p-0 min-h-fit">
-              <div className="flex items-center gap-2 w-11/12">
+            <TableCellWrapper className="p-3 min-h-fit">
+              <div className="flex items-center gap-3 w-11/12">
                 {props.row.original.blueprintData?.metadata?.logo ? (
                   <Avatar
                     size="lg"
-                    className="min-w-12"
+                    className="min-w-12 shadow-sm"
                     src={props.row.original.blueprintData.metadata?.logo}
                     alt={props.row.original.id.toString()}
                     sourceVariant="uri"
@@ -192,7 +192,7 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                 ) : (
                   <Avatar
                     size="lg"
-                    className="min-w-12"
+                    className="min-w-12 shadow-sm"
                     sourceVariant="address"
                     value={
                       (props.row.original.blueprintData?.metadata as any)
@@ -220,26 +220,26 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                   <Typography
                     variant="body1"
                     fw="bold"
-                    className="!text-blue-50 text-ellipsis whitespace-nowrap overflow-hidden"
+                    className="text-mono-200 dark:text-mono-0 text-ellipsis whitespace-nowrap overflow-hidden"
                   >
                     {props.row.original.blueprintData?.metadata?.author || ''}
                   </Typography>
                   <Typography
                     variant="body2"
                     fw="normal"
-                    className="!text-mono-100 text-ellipsis whitespace-nowrap overflow-hidden"
+                    className="text-mono-140 dark:text-mono-80 text-ellipsis whitespace-nowrap overflow-hidden"
                   >
                     {props.row.original.blueprintData?.metadata?.name || ''}
                   </Typography>
                 </div>
                 <div>
-                  <ChevronRight className="w-6 h-6" />
+                  <ChevronRight className="w-6 h-6 text-mono-120 dark:text-mono-100" />
                 </div>
                 <div className="w-4/12">
                   <Typography
                     variant="body1"
                     fw="bold"
-                    className="!text-blue-50 text-ellipsis whitespace-nowrap overflow-hidden"
+                    className="text-blue-70 dark:text-blue-40 text-ellipsis whitespace-nowrap overflow-hidden"
                   >
                     {props.row.original.id
                       ? `Instance-${props.row.original.id}`
@@ -248,7 +248,7 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                   {/* <Typography
                     variant="body2"
                     fw="normal"
-                    className="!text-mono-100 text-ellipsis whitespace-nowrap overflow-hidden"
+                    className="text-mono-140 dark:text-mono-80 text-ellipsis whitespace-nowrap overflow-hidden"
                   >
                     {props.row.original.externalInstanceId ||
                       EMPTY_VALUE_PLACEHOLDER}
@@ -279,8 +279,8 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
           }
 
           return (
-            <TableCellWrapper removeRightBorder className="p-0 min-h-fit">
-              <div className="flex gap-2">
+            <TableCellWrapper removeRightBorder className="p-3 min-h-fit">
+              <div className="flex gap-3">
                 <Link
                   to={PagePath.BLUEPRINTS_DETAILS.replace(
                     ':id',
@@ -290,7 +290,10 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                     event.stopPropagation();
                   }}
                 >
-                  <Button variant="utility" className="uppercase body4">
+                  <Button 
+                    variant="utility" 
+                    className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200"
+                  >
                     View
                   </Button>
                 </Link>
@@ -298,7 +301,7 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                 {isOwner && (
                   <Button
                     variant="utility"
-                    className="uppercase body4 !bg-red-500 !text-white hover:!bg-red-600"
+                    className="uppercase body4 bg-red-10 dark:bg-red-120 text-red-70 dark:text-red-40 hover:bg-red-20 dark:hover:bg-red-110 border border-red-30 dark:border-red-100 transition-all duration-200"
                     onClick={(event) => {
                       event.stopPropagation();
                       handleTerminateClick(props.row.original);

--- a/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/RunningInstanceTable.tsx
@@ -290,8 +290,8 @@ export const RunningInstanceTable: FC<RunningInstanceTableProps> = ({
                     event.stopPropagation();
                   }}
                 >
-                  <Button 
-                    variant="utility" 
+                  <Button
+                    variant="utility"
                     className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200"
                   >
                     View

--- a/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
@@ -1,6 +1,6 @@
 import { TableAndChartTabs } from '@tangle-network/ui-components/components/TableAndChartTabs';
 import { PlayFillIcon, TimeLineIcon } from '@tangle-network/icons';
-import { FC, ReactElement, useState } from 'react';
+import { FC, ReactElement, useState, Dispatch, SetStateAction } from 'react';
 import { TabContent } from '@tangle-network/ui-components';
 import { RunningInstanceTable } from './RunningInstanceTable';
 import { PendingInstanceTable } from './PendingInstanceTable';
@@ -15,7 +15,15 @@ const InstancesTabIcon: ReactElement[] = [
   <TimeLineIcon className="w-4 h-4 !fill-yellow-100" />,
 ] as const;
 
-export const InstancesTabs: FC = () => {
+interface InstancesTabsProps {
+  refreshTrigger: number;
+  setRefreshTrigger: Dispatch<SetStateAction<number>>;
+}
+
+export const InstancesTabs: FC<InstancesTabsProps> = ({
+  refreshTrigger,
+  setRefreshTrigger,
+}) => {
   const [selectedTab, setSelectedTab] = useState(
     InstancesTab.RUNNING_INSTANCES,
   );
@@ -33,14 +41,20 @@ export const InstancesTabs: FC = () => {
         value={InstancesTab.RUNNING_INSTANCES}
         className="flex justify-center mx-auto"
       >
-        <RunningInstanceTable />
+        <RunningInstanceTable
+          refreshTrigger={refreshTrigger}
+          setRefreshTrigger={setRefreshTrigger}
+        />
       </TabContent>
 
       <TabContent
         value={InstancesTab.PENDING_INSTANCES}
         className="flex justify-center mx-auto"
       >
-        <PendingInstanceTable />
+        <PendingInstanceTable
+          refreshTrigger={refreshTrigger}
+          setRefreshTrigger={setRefreshTrigger}
+        />
       </TabContent>
     </TableAndChartTabs>
   );

--- a/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
@@ -1,6 +1,13 @@
 import { TableAndChartTabs } from '@tangle-network/ui-components/components/TableAndChartTabs';
 import { PlayFillIcon, TimeLineIcon } from '@tangle-network/icons';
-import { FC, ReactElement, useState, Dispatch, SetStateAction, useMemo } from 'react';
+import {
+  FC,
+  ReactElement,
+  useState,
+  Dispatch,
+  SetStateAction,
+  useMemo,
+} from 'react';
 import { TabContent } from '@tangle-network/ui-components';
 import { RunningInstanceTable } from './RunningInstanceTable';
 import { PendingInstanceTable } from './PendingInstanceTable';

--- a/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
+++ b/apps/tangle-cloud/src/pages/instances/Instances/index.tsx
@@ -1,9 +1,13 @@
 import { TableAndChartTabs } from '@tangle-network/ui-components/components/TableAndChartTabs';
 import { PlayFillIcon, TimeLineIcon } from '@tangle-network/icons';
-import { FC, ReactElement, useState, Dispatch, SetStateAction } from 'react';
+import { FC, ReactElement, useState, Dispatch, SetStateAction, useMemo } from 'react';
 import { TabContent } from '@tangle-network/ui-components';
 import { RunningInstanceTable } from './RunningInstanceTable';
 import { PendingInstanceTable } from './PendingInstanceTable';
+import useOperatorInfo from '@tangle-network/tangle-shared-ui/hooks/useOperatorInfo';
+import { useOperatorStatsData } from '../../../data/operators/useOperatorStatsData';
+import useActiveAccountAddress from '@tangle-network/tangle-shared-ui/hooks/useActiveAccountAddress';
+import { isSubstrateAddress } from '@tangle-network/ui-components';
 
 enum InstancesTab {
   RUNNING_INSTANCES = 'Running',
@@ -24,14 +28,46 @@ export const InstancesTabs: FC<InstancesTabsProps> = ({
   refreshTrigger,
   setRefreshTrigger,
 }) => {
+  const { isOperator } = useOperatorInfo();
+  const accountAddress = useActiveAccountAddress();
+
+  const { result: operatorStatsData } = useOperatorStatsData(
+    useMemo(() => {
+      if (
+        !accountAddress ||
+        !isOperator ||
+        !isSubstrateAddress(accountAddress)
+      ) {
+        return null;
+      }
+
+      return accountAddress;
+    }, [accountAddress, isOperator]),
+    refreshTrigger,
+  );
+
+  const hasRegisteredBlueprints = useMemo(() => {
+    return operatorStatsData && operatorStatsData.registeredBlueprints > 0;
+  }, [operatorStatsData]);
+
+  const shouldShowPendingTab = isOperator && hasRegisteredBlueprints;
+
+  const availableTabs = shouldShowPendingTab
+    ? Object.values(InstancesTab)
+    : [InstancesTab.RUNNING_INSTANCES];
+
+  const availableIcons = shouldShowPendingTab
+    ? InstancesTabIcon
+    : [InstancesTabIcon[0]];
+
   const [selectedTab, setSelectedTab] = useState(
     InstancesTab.RUNNING_INSTANCES,
   );
 
   return (
     <TableAndChartTabs
-      tabs={Object.values(InstancesTab)}
-      icons={InstancesTabIcon}
+      tabs={availableTabs}
+      icons={availableIcons}
       value={selectedTab}
       onValueChange={(tab) => setSelectedTab(tab as InstancesTab)}
       className="space-y-9 w-full"
@@ -47,15 +83,17 @@ export const InstancesTabs: FC<InstancesTabsProps> = ({
         />
       </TabContent>
 
-      <TabContent
-        value={InstancesTab.PENDING_INSTANCES}
-        className="flex justify-center mx-auto"
-      >
-        <PendingInstanceTable
-          refreshTrigger={refreshTrigger}
-          setRefreshTrigger={setRefreshTrigger}
-        />
-      </TabContent>
+      {shouldShowPendingTab && (
+        <TabContent
+          value={InstancesTab.PENDING_INSTANCES}
+          className="flex justify-center mx-auto"
+        >
+          <PendingInstanceTable
+            refreshTrigger={refreshTrigger}
+            setRefreshTrigger={setRefreshTrigger}
+          />
+        </TabContent>
+      )}
     </TableAndChartTabs>
   );
 };

--- a/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
+++ b/apps/tangle-cloud/src/pages/instances/InstructionCard.tsx
@@ -12,39 +12,40 @@ type InstructionCardProps = {
 export const InstructionCard: FC<InstructionCardProps> = ({ rootProps }) => {
   return (
     <TangleCloudCard {...rootProps}>
-      <ul className="h-full flex flex-col justify-between gap-4">
+      <ul className="h-full flex flex-col justify-between gap-6">
         {Children.toArray(
           CLOUD_INSTRUCTIONS.map((instruction) => (
             <ListItem
               className={twMerge('w-full px-0', 'opacity-100 p-0')}
               isDisabled
             >
-              <div className="flex gap-4 w-full flex-wrap xs:flex-nowrap justify-center xs:justify-start">
+              <div className="flex gap-5 w-full flex-wrap xs:flex-nowrap justify-center xs:justify-start items-start">
                 <Chip
                   color="dark-grey"
-                  className="bg-mono-120/[10%] dark:bg-mono-0/[20%] min-w-14 h-14 flex items-center justify-center"
+                  className="bg-blue-10 dark:bg-blue-120 border border-blue-30 dark:border-blue-100 min-w-16 h-16 flex items-center justify-center shadow-sm hover:shadow-md transition-all duration-200"
                 >
                   {createElement(instruction.icon, {
-                    className: instruction.className,
+                    className: 'h-7 w-7 fill-blue-70 dark:fill-blue-40',
                   })}
                 </Chip>
-                <div className="gap-1 flex flex-col items-center xs:items-start">
+                <div className="gap-2 flex flex-col items-center xs:items-start flex-1">
                   <Link
                     href={instruction.to}
                     target={instruction.external ? '_blank' : '_self'}
                     rel={instruction.external ? 'noopener noreferrer' : ''}
+                    className="hover:no-underline group"
                   >
                     <Typography
-                      variant="body1"
+                      variant="h5"
                       fw="bold"
-                      className="text-blue-60 dark:text-blue-40"
+                      className="text-blue-70 dark:text-blue-40 group-hover:text-blue-80 dark:group-hover:text-blue-30 transition-colors duration-200 leading-tight"
                     >
                       {instruction.title}
                     </Typography>
                   </Link>
                   <Typography
-                    variant="body1"
-                    className="!text-mono-100 text-center xs:text-left"
+                    variant="body2"
+                    className="text-mono-140 dark:text-mono-80 text-center xs:text-left leading-relaxed"
                   >
                     {instruction.description}
                   </Typography>

--- a/apps/tangle-cloud/src/pages/instances/RegisteredBlueprints/RegisteredBlueprints.tsx
+++ b/apps/tangle-cloud/src/pages/instances/RegisteredBlueprints/RegisteredBlueprints.tsx
@@ -107,8 +107,8 @@ export const RegisteredBlueprints: FC = () => {
         cell: (props) => {
           return (
             <TableCellWrapper className="p-3 min-h-fit">
-              <Typography 
-                variant="body1" 
+              <Typography
+                variant="body1"
                 fw="semibold"
                 className="text-mono-160 dark:text-mono-60"
               >
@@ -124,8 +124,8 @@ export const RegisteredBlueprints: FC = () => {
         cell: (props) => {
           return (
             <TableCellWrapper className="p-3 min-h-fit">
-              <Typography 
-                variant="body1" 
+              <Typography
+                variant="body1"
                 fw="semibold"
                 className="text-mono-160 dark:text-mono-60"
               >
@@ -165,8 +165,8 @@ export const RegisteredBlueprints: FC = () => {
                   event.stopPropagation();
                 }}
               >
-                <Button 
-                  variant="utility" 
+                <Button
+                  variant="utility"
                   className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200"
                 >
                   View

--- a/apps/tangle-cloud/src/pages/instances/RegisteredBlueprints/RegisteredBlueprints.tsx
+++ b/apps/tangle-cloud/src/pages/instances/RegisteredBlueprints/RegisteredBlueprints.tsx
@@ -54,12 +54,12 @@ export const RegisteredBlueprints: FC = () => {
         header: () => 'Blueprint',
         cell: (props) => {
           return (
-            <TableCellWrapper className="p-0 min-h-fit">
-              <div className="flex items-center gap-2 overflow-hidden">
+            <TableCellWrapper className="p-3 min-h-fit">
+              <div className="flex items-center gap-3 overflow-hidden">
                 {props.row.original.blueprint.metadata.logo ? (
                   <Avatar
                     size="lg"
-                    className="min-w-12"
+                    className="min-w-12 shadow-sm"
                     src={props.row.original.blueprint.metadata.logo}
                     alt={props.row.original.blueprint.metadata.name}
                     sourceVariant="uri"
@@ -67,7 +67,7 @@ export const RegisteredBlueprints: FC = () => {
                 ) : (
                   <Avatar
                     size="lg"
-                    className="min-w-12"
+                    className="min-w-12 shadow-sm"
                     sourceVariant="address"
                     value={
                       (props.row.original.blueprint.metadata.author &&
@@ -92,7 +92,7 @@ export const RegisteredBlueprints: FC = () => {
                 <Typography
                   variant="body1"
                   fw="bold"
-                  className="!text-blue-50 text-ellipsis whitespace-nowrap overflow-hidden"
+                  className="text-mono-200 dark:text-mono-0 text-ellipsis whitespace-nowrap overflow-hidden"
                 >
                   {props.row.original.blueprint.metadata.name}
                 </Typography>
@@ -106,8 +106,12 @@ export const RegisteredBlueprints: FC = () => {
         header: () => 'Instances',
         cell: (props) => {
           return (
-            <TableCellWrapper className="p-0 min-h-fit">
-              <Typography variant="body1" fw="normal">
+            <TableCellWrapper className="p-3 min-h-fit">
+              <Typography 
+                variant="body1" 
+                fw="semibold"
+                className="text-mono-160 dark:text-mono-60"
+              >
                 {props.row.original.blueprint.instanceCount?.toLocaleString() ??
                   EMPTY_VALUE_PLACEHOLDER}
               </Typography>
@@ -119,9 +123,15 @@ export const RegisteredBlueprints: FC = () => {
         header: () => 'Operators',
         cell: (props) => {
           return (
-            <TableCellWrapper className="p-0 min-h-fit">
-              {props.row.original.blueprint.operatorsCount?.toLocaleString() ??
-                EMPTY_VALUE_PLACEHOLDER}
+            <TableCellWrapper className="p-3 min-h-fit">
+              <Typography 
+                variant="body1" 
+                fw="semibold"
+                className="text-mono-160 dark:text-mono-60"
+              >
+                {props.row.original.blueprint.operatorsCount?.toLocaleString() ??
+                  EMPTY_VALUE_PLACEHOLDER}
+              </Typography>
             </TableCellWrapper>
           );
         },
@@ -145,7 +155,7 @@ export const RegisteredBlueprints: FC = () => {
         header: () => '',
         cell: (props) => {
           return (
-            <TableCellWrapper removeRightBorder className="p-0 min-h-fit">
+            <TableCellWrapper removeRightBorder className="p-3 min-h-fit">
               <Link
                 to={PagePath.BLUEPRINTS_DETAILS.replace(
                   ':id',
@@ -155,7 +165,10 @@ export const RegisteredBlueprints: FC = () => {
                   event.stopPropagation();
                 }}
               >
-                <Button variant="utility" className="uppercase body4">
+                <Button 
+                  variant="utility" 
+                  className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200"
+                >
                   View
                 </Button>
               </Link>

--- a/apps/tangle-cloud/src/pages/instances/page.tsx
+++ b/apps/tangle-cloud/src/pages/instances/page.tsx
@@ -1,16 +1,22 @@
+import { useState } from 'react';
 import { AccountStatsCard } from './AccountStatsCard';
 import { InstructionCard } from './InstructionCard';
 import { TotalValueLockedTabs } from './TotalValueLocked';
 import { BlueprintManagementSection } from './BlueprintManagementSection';
 
 const Page = () => {
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
   return (
     <>
       <div className="flex justify-between flex-wrap md:flex-nowrap gap-5">
-        <AccountStatsCard />
+        <AccountStatsCard refreshTrigger={refreshTrigger} />
         <InstructionCard />
       </div>
-      <BlueprintManagementSection />
+      <BlueprintManagementSection
+        refreshTrigger={refreshTrigger}
+        setRefreshTrigger={setRefreshTrigger}
+      />
       <TotalValueLockedTabs />
     </>
   );

--- a/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
+++ b/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
@@ -32,8 +32,8 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
     >
       <div className="space-y-6 flex-1">
         <div className="space-y-4">
-          <Typography 
-            variant="h4" 
+          <Typography
+            variant="h4"
             className="text-mono-0 dark:text-mono-0 font-bold leading-tight drop-shadow-sm"
           >
             {title}
@@ -63,11 +63,7 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
         </Button>
       </div>
 
-      {action && (
-        <div className="flex-shrink-0">
-          {action}
-        </div>
-      )}
+      {action && <div className="flex-shrink-0">{action}</div>}
     </div>
   );
 };

--- a/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
+++ b/libs/tangle-shared-ui/src/components/blueprints/RestakeBanner.tsx
@@ -23,32 +23,39 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
   return (
     <div
       className={twMerge(
-        'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-6 sm:gap-9 px-6 py-9 rounded-xl bg-center bg-cover bg-no-repeat bg-top-banner',
+        'flex flex-col sm:flex-row justify-between items-start sm:items-center gap-6 sm:gap-8',
+        'px-8 py-10 rounded-2xl bg-center bg-cover bg-no-repeat bg-top-banner',
+        'border border-mono-40 dark:border-mono-160',
+        'shadow-lg dark:shadow-xl',
+        'transition-all duration-200 hover:shadow-xl dark:hover:shadow-2xl',
       )}
     >
-      <div className="space-y-4">
-        <div className="space-y-3">
-          <Typography variant="h4" className="text-mono-0">
+      <div className="space-y-6 flex-1">
+        <div className="space-y-4">
+          <Typography 
+            variant="h4" 
+            className="text-mono-0 dark:text-mono-0 font-bold leading-tight drop-shadow-sm"
+          >
             {title}
           </Typography>
 
           <Typography
             variant="body1"
-            className="text-mono-60 dark:text-mono-100"
+            className="text-mono-20 dark:text-mono-80 leading-relaxed max-w-2xl drop-shadow-sm"
           >
             {description}
           </Typography>
         </div>
 
         <Button
-          className="hidden sm:flex"
+          className="hidden sm:inline-flex font-semibold text-blue-40 dark:text-blue-50 hover:text-blue-30 dark:hover:text-blue-30"
           variant="link"
           href={buttonHref}
           target="_blank"
           rightIcon={
             <ArrowRightUp
               size="lg"
-              className="fill-current dark:fill-current"
+              className="fill-blue-40 dark:fill-blue-50 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 hover:fill-blue-30 dark:hover:fill-blue-30"
             />
           }
         >
@@ -56,7 +63,11 @@ const RestakeBanner: FC<RestakeBannerProps> = ({
         </Button>
       </div>
 
-      {action}
+      {action && (
+        <div className="flex-shrink-0">
+          {action}
+        </div>
+      )}
     </div>
   );
 };

--- a/libs/tangle-shared-ui/src/components/tables/Operators/index.tsx
+++ b/libs/tangle-shared-ui/src/components/tables/Operators/index.tsx
@@ -68,8 +68,8 @@ const getStaticColumns = (
 
             <div className="flex-1">
               <div className="flex items-center gap-2 mb-1">
-                <Typography 
-                  variant="h5" 
+                <Typography
+                  variant="h5"
                   fw="bold"
                   className="text-mono-200 dark:text-mono-0"
                 >
@@ -78,15 +78,17 @@ const getStaticColumns = (
 
                 {isDelegated && (
                   <IconWithTooltip
-                    icon={<CheckboxCircleFill className="!fill-green-60 dark:!fill-green-50" />}
+                    icon={
+                      <CheckboxCircleFill className="!fill-green-60 dark:!fill-green-50" />
+                    }
                     content="Delegated"
                   />
                 )}
               </div>
 
-              <KeyValueWithButton 
-                keyValue={address} 
-                size="sm" 
+              <KeyValueWithButton
+                keyValue={address}
+                size="sm"
                 className="text-mono-140 dark:text-mono-80"
               />
             </div>
@@ -217,8 +219,8 @@ const getStaticColumns = (
           {tokensList.length > 0 ? (
             <VaultsDropdown vaultTokens={tokensList} />
           ) : (
-            <Typography 
-              variant="body1" 
+            <Typography
+              variant="body1"
               className="text-mono-140 dark:text-mono-80"
             >
               No vaults
@@ -277,16 +279,16 @@ const OperatorsTable: FC<Props> = ({
             <div className="flex items-center justify-end flex-1 gap-2">
               {RestakeOperatorAction ? (
                 <RestakeOperatorAction address={props.row.original.address}>
-                  <Button 
-                    variant="utility" 
+                  <Button
+                    variant="utility"
                     className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200 font-semibold"
                   >
                     Delegate
                   </Button>
                 </RestakeOperatorAction>
               ) : (
-                <Button 
-                  variant="utility" 
+                <Button
+                  variant="utility"
                   className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200 font-semibold"
                 >
                   Delegate

--- a/libs/tangle-shared-ui/src/components/tables/Operators/index.tsx
+++ b/libs/tangle-shared-ui/src/components/tables/Operators/index.tsx
@@ -56,30 +56,39 @@ const getStaticColumns = (
       const address = toSubstrateAddress(rawAddress, ss58Prefix);
 
       return (
-        <TableCellWrapper className="pl-3">
-          <div className="flex items-center flex-1 gap-2 pr-3">
+        <TableCellWrapper className="p-3">
+          <div className="flex items-center flex-1 gap-3 pr-3">
             <Avatar
               sourceVariant="address"
               value={address}
               theme="substrate"
               size="lg"
+              className="shadow-sm"
             />
 
-            <div>
-              <div className="flex items-center gap-2">
-                <Typography variant="h5" fw="bold">
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <Typography 
+                  variant="h5" 
+                  fw="bold"
+                  className="text-mono-200 dark:text-mono-0"
+                >
                   {identity ? identity : shortenString(address)}
                 </Typography>
 
                 {isDelegated && (
                   <IconWithTooltip
-                    icon={<CheckboxCircleFill className="!fill-green-50" />}
+                    icon={<CheckboxCircleFill className="!fill-green-60 dark:!fill-green-50" />}
                     content="Delegated"
                   />
                 )}
               </div>
 
-              <KeyValueWithButton keyValue={address} size="sm" />
+              <KeyValueWithButton 
+                keyValue={address} 
+                size="sm" 
+                className="text-mono-140 dark:text-mono-80"
+              />
             </div>
           </div>
         </TableCellWrapper>
@@ -92,18 +101,20 @@ const getStaticColumns = (
       const value = props.getValue();
 
       return (
-        <TableCellWrapper>
+        <TableCellWrapper className="p-3">
           <Typography
             variant="body1"
-            fw="bold"
-            className="text-mono-200 dark:text-mono-0"
+            fw="semibold"
+            className="text-mono-160 dark:text-mono-60"
           >
             {formatDisplayAmount(
               new BN(value.toString()),
               TANGLE_TOKEN_DECIMALS,
               AmountFormatStyle.SHORT,
             )}{' '}
-            {nativeTokenSymbol}
+            <span className="text-mono-120 dark:text-mono-100">
+              {nativeTokenSymbol}
+            </span>
           </Typography>
         </TableCellWrapper>
       );
@@ -112,11 +123,11 @@ const getStaticColumns = (
   COLUMN_HELPER.accessor('instanceCount', {
     header: () => 'Instances',
     cell: (props) => (
-      <TableCellWrapper>
+      <TableCellWrapper className="p-3">
         <Typography
           variant="body1"
-          fw="bold"
-          className="text-mono-200 dark:text-mono-0"
+          fw="semibold"
+          className="text-mono-160 dark:text-mono-60"
         >
           {props.getValue() ?? 0}
         </Typography>
@@ -126,11 +137,11 @@ const getStaticColumns = (
   COLUMN_HELPER.accessor('restakersCount', {
     header: () => 'Restakers',
     cell: (props) => (
-      <TableCellWrapper>
+      <TableCellWrapper className="p-3">
         <Typography
           variant="body1"
-          fw="bold"
-          className="text-mono-200 dark:text-mono-0"
+          fw="semibold"
+          className="text-mono-160 dark:text-mono-60"
         >
           {props.getValue()}
         </Typography>
@@ -202,11 +213,16 @@ const getStaticColumns = (
       const tokensList = props.getValue();
 
       return (
-        <TableCellWrapper removeRightBorder>
+        <TableCellWrapper removeRightBorder className="p-3">
           {tokensList.length > 0 ? (
             <VaultsDropdown vaultTokens={tokensList} />
           ) : (
-            <Typography variant="body1">No vaults</Typography>
+            <Typography 
+              variant="body1" 
+              className="text-mono-140 dark:text-mono-80"
+            >
+              No vaults
+            </Typography>
           )}
         </TableCellWrapper>
       );
@@ -257,16 +273,22 @@ const OperatorsTable: FC<Props> = ({
         id: 'actions',
         header: () => null,
         cell: (props) => (
-          <TableCellWrapper removeRightBorder>
+          <TableCellWrapper removeRightBorder className="p-3">
             <div className="flex items-center justify-end flex-1 gap-2">
               {RestakeOperatorAction ? (
                 <RestakeOperatorAction address={props.row.original.address}>
-                  <Button variant="utility" className="uppercase body4">
+                  <Button 
+                    variant="utility" 
+                    className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200 font-semibold"
+                  >
                     Delegate
                   </Button>
                 </RestakeOperatorAction>
               ) : (
-                <Button variant="utility" className="uppercase body4">
+                <Button 
+                  variant="utility" 
+                  className="uppercase body4 bg-blue-10 dark:bg-blue-120 text-blue-70 dark:text-blue-40 hover:bg-blue-20 dark:hover:bg-blue-110 border border-blue-30 dark:border-blue-100 transition-all duration-200 font-semibold"
+                >
                   Delegate
                 </Button>
               )}

--- a/libs/tangle-shared-ui/src/data/blueprints/useMonitoringBlueprints.ts
+++ b/libs/tangle-shared-ui/src/data/blueprints/useMonitoringBlueprints.ts
@@ -17,6 +17,7 @@ import { SubstrateAddress } from '@tangle-network/ui-components/types/address';
 
 const useMonitoringBlueprints = (
   operatorAccountAddress?: SubstrateAddress | null,
+  refreshTrigger?: number,
 ) => {
   const { operatorTvlByAsset } = useOperatorTvl();
 
@@ -124,7 +125,8 @@ const useMonitoringBlueprints = (
           }),
         );
       },
-      [operatorAccountAddress, operatorTvlByAsset],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [operatorAccountAddress, operatorTvlByAsset, refreshTrigger],
     ),
   );
 

--- a/libs/tangle-shared-ui/src/data/blueprints/usePendingServiceRequest.ts
+++ b/libs/tangle-shared-ui/src/data/blueprints/usePendingServiceRequest.ts
@@ -18,6 +18,7 @@ import { AccountId32 } from '@polkadot/types/interfaces';
 
 const usePendingServiceRequest = (
   operatorAccountAddress: SubstrateAddress | null,
+  refreshTrigger?: number,
 ) => {
   const { network } = useNetworkStore();
   const { result: serviceRequestEntries } = useApiRx(
@@ -39,7 +40,8 @@ const usePendingServiceRequest = (
           }),
         );
       },
-      [operatorAccountAddress],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [operatorAccountAddress, refreshTrigger],
     ),
   );
 


### PR DESCRIPTION
## Summary of changes

- add automatic table refresh after service instance state changes
- validate operator address against operator map in useOperatorInfo hook
- conditionally show operator UI based on registered blueprints
- add operator chip indicator to account stats card header
- enhance RestakeBanner with improved styling, dark mode support and hover effects
- enhance TangleCloud and instruction cards with improved ui and hover effects
- update table cell styles
- enhance operators table UI with improved dark mode and loading states

### Proposed area of change

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `apps/leaderboard`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Screenshots & Screen Recording

<img width="2596" height="724" alt="CleanShot 2025-07-24 at 14 36 31@2x" src="https://github.com/user-attachments/assets/60740449-2fb0-45f4-9a91-5e8cfd410b4c" />

https://github.com/user-attachments/assets/0a3984b2-88df-490e-82cb-4b8b03cbd32b