### PR TITLE
chore(tangle-dapp): Restake Improvements & Fixes

### DIFF
--- a/apps/leaderboard/src/utils/getRpcEndpoint.ts
+++ b/apps/leaderboard/src/utils/getRpcEndpoint.ts
@@ -1,5 +1,5 @@
 import {
-  TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
+  TANGLE_MAINNET_WS_RPC_ENDPOINT,
   TANGLE_TESTNET_WS_RPC_ENDPOINT,
 } from '@tangle-network/dapp-config';
 import { Network } from '../types';
@@ -12,12 +12,12 @@ type GetRpcEndpointResult<TNetwork extends Network> = TNetwork extends 'TESTNET'
   : TNetwork extends 'MAINNET'
     ? {
         testnetRpc: undefined;
-        mainnetRpc: typeof TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT;
+        mainnetRpc: typeof TANGLE_MAINNET_WS_RPC_ENDPOINT;
       }
     : TNetwork extends 'ALL'
       ? {
           testnetRpc: typeof TANGLE_TESTNET_WS_RPC_ENDPOINT;
-          mainnetRpc: typeof TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT;
+          mainnetRpc: typeof TANGLE_MAINNET_WS_RPC_ENDPOINT;
         }
       : never;
 
@@ -33,12 +33,12 @@ export function getRpcEndpoint<TNetwork extends Network>(
     case 'MAINNET':
       return {
         testnetRpc: undefined,
-        mainnetRpc: TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
+        mainnetRpc: TANGLE_MAINNET_WS_RPC_ENDPOINT,
       } as GetRpcEndpointResult<TNetwork>;
     case 'ALL':
       return {
         testnetRpc: TANGLE_TESTNET_WS_RPC_ENDPOINT,
-        mainnetRpc: TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
+        mainnetRpc: TANGLE_MAINNET_WS_RPC_ENDPOINT,
       } as GetRpcEndpointResult<TNetwork>;
     default:
       throw new Error(`Invalid network: ${network}`);

--- a/apps/tangle-dapp/src/components/Lists/AssetListItem.tsx
+++ b/apps/tangle-dapp/src/components/Lists/AssetListItem.tsx
@@ -21,6 +21,8 @@ type Props = {
   decimals: number;
   rightBottomText?: string;
   leftBottomContentTwo?: string;
+  label?: string;
+  labelColor?: 'green' | 'purple' | 'blue' | 'red' | 'yellow';
 };
 
 const AssetListItem = ({
@@ -31,6 +33,8 @@ const AssetListItem = ({
   decimals,
   rightBottomText = 'Balance',
   leftBottomContentTwo,
+  label,
+  labelColor,
 }: Props) => {
   const activeChain = useActiveChain();
 
@@ -82,10 +86,40 @@ const AssetListItem = ({
       </Typography>
     );
 
+  // Create the display name with label
+  const displayName = (() => {
+    if (name === undefined) {
+      return symbol;
+    }
+
+    if (label && labelColor) {
+      return (
+        <div className="flex items-center gap-2">
+          <span>
+            {name} ({symbol})
+          </span>
+          <span
+            className={`px-2 py-1 rounded text-xs font-medium ${
+              labelColor === 'green'
+                ? 'bg-green-100 text-mono-0 dark:bg-green-900 dark:text-mono-0'
+                : labelColor === 'purple'
+                  ? 'bg-purple-900 text-mono-0 dark:bg-purple-900 dark:text-mono-0'
+                  : 'bg-blue-900 text-mono-0 dark:bg-blue-900 dark:text-mono-0'
+            }`}
+          >
+            {label}
+          </span>
+        </div>
+      );
+    }
+
+    return `${name} (${symbol})`;
+  })();
+
   return (
     <LogoListItem
       logo={<TokenIcon size="xl" name={symbol} />}
-      leftUpperContent={name !== undefined ? `${name} (${symbol})` : symbol}
+      leftUpperContent={displayName}
       leftBottomContent={leftBottomContent}
       leftBottomContentTwo={leftBottomContentTwo}
       rightUpperText={`${fmtBalance} ${symbol}`}

--- a/apps/tangle-dapp/src/components/Lists/OperatorListItem.tsx
+++ b/apps/tangle-dapp/src/components/Lists/OperatorListItem.tsx
@@ -1,7 +1,6 @@
 import { SubstrateAddress } from '@tangle-network/ui-components/types/address';
 import {
   Avatar,
-  EMPTY_VALUE_PLACEHOLDER,
   KeyValueWithButton,
   shortenString,
 } from '@tangle-network/ui-components';
@@ -36,7 +35,7 @@ const OperatorListItem: FC<Props> = ({
           valueVariant="body1"
         />
       }
-      rightUpperText={rightUpperText ?? EMPTY_VALUE_PLACEHOLDER}
+      rightUpperText={rightUpperText}
       rightBottomText={rightBottomText}
     />
   );

--- a/apps/tangle-dapp/src/components/Sidebar/sidebarProps.tsx
+++ b/apps/tangle-dapp/src/components/Sidebar/sidebarProps.tsx
@@ -24,7 +24,7 @@ import {
   TANGLE_MKT_URL,
 } from '@tangle-network/ui-components/constants';
 // import { PointsBanner } from '../../features/points/components/PointsBanner';
-import { PagePath } from '../../types';
+import { NetworkFeature, PagePath } from '../../types';
 
 // TODO: This entire system of handling sidebar props can be improved in a more React-compliant manner. For now, leaving as is since it is not necessary.
 // Only show the services dropdown if on development mode.
@@ -84,10 +84,12 @@ export default function getSidebarProps({
   polkadotJsDashboardUrl,
   nativeExplorerUrl,
   evmExplorerUrl,
+  networkFeatures,
 }: {
   polkadotJsDashboardUrl: string;
   nativeExplorerUrl?: string;
   evmExplorerUrl?: string;
+  networkFeatures: readonly NetworkFeature[];
 }): MobileSidebarProps {
   const isProductionEnv = import.meta.env.PROD;
 
@@ -122,13 +124,17 @@ export default function getSidebarProps({
           },
         ]
       : []),
-    {
-      name: 'Testnet Faucet',
-      href: TANGLE_FAUCET_URL,
-      isInternal: false,
-      Icon: FaucetIcon,
-      subItems: [],
-    },
+    ...(networkFeatures.includes(NetworkFeature.Faucet)
+      ? [
+          {
+            name: 'Testnet Faucet',
+            href: TANGLE_FAUCET_URL,
+            isInternal: false,
+            Icon: FaucetIcon,
+            subItems: [],
+          },
+        ]
+      : []),
   ];
 
   // Filter the sidebar items based on the current environment.

--- a/apps/tangle-dapp/src/components/Sidebar/sidebarProps.tsx
+++ b/apps/tangle-dapp/src/components/Sidebar/sidebarProps.tsx
@@ -3,13 +3,13 @@ import {
   CoinLine,
   DocumentationIcon,
   FaucetIcon,
-  GiftLineIcon,
+  // GiftLineIcon,
   GlobalLine,
   HomeFillIcon,
   PolkadotJs,
   ShuffleLine,
   TokenSwapFill,
-  WaterDropletIcon,
+  // WaterDropletIcon,
 } from '@tangle-network/icons';
 import {
   MobileSidebarProps,
@@ -23,7 +23,7 @@ import {
   TANGLE_FAUCET_URL,
   TANGLE_MKT_URL,
 } from '@tangle-network/ui-components/constants';
-import { PointsBanner } from '../../features/points/components/PointsBanner';
+// import { PointsBanner } from '../../features/points/components/PointsBanner';
 import { PagePath } from '../../types';
 
 // TODO: This entire system of handling sidebar props can be improved in a more React-compliant manner. For now, leaving as is since it is not necessary.
@@ -43,13 +43,13 @@ const SIDEBAR_STATIC_ITEMS: SideBarItemProps[] = [
     Icon: TokenSwapFill,
     subItems: [],
   },
-  {
-    name: 'Liquid Stake',
-    href: PagePath.LIQUID_STAKING,
-    isInternal: true,
-    Icon: WaterDropletIcon,
-    subItems: [],
-  },
+  // {
+  //   name: 'Liquid Stake',
+  //   href: PagePath.LIQUID_STAKING,
+  //   isInternal: true,
+  //   Icon: WaterDropletIcon,
+  //   subItems: [],
+  // },
   {
     name: 'Bridge',
     href: PagePath.BRIDGE,
@@ -64,13 +64,13 @@ const SIDEBAR_STATIC_ITEMS: SideBarItemProps[] = [
     Icon: CoinLine,
     subItems: [],
   },
-  {
-    name: 'Claim Airdrop',
-    href: PagePath.CLAIM_AIRDROP,
-    isInternal: true,
-    Icon: GiftLineIcon,
-    subItems: [],
-  },
+  // {
+  //   name: 'Claim Airdrop',
+  //   href: PagePath.CLAIM_AIRDROP,
+  //   isInternal: true,
+  //   Icon: GiftLineIcon,
+  //   subItems: [],
+  // },
 ];
 
 const SIDEBAR_FOOTER: SideBarFooterType = {
@@ -146,7 +146,7 @@ export default function getSidebarProps({
     Logo: TangleLogo,
     footer: {
       ...SIDEBAR_FOOTER,
-      extraContent: <PointsBanner />,
+      // extraContent: <PointsBanner />,
     },
     items,
     logoLink: TANGLE_MKT_URL,

--- a/apps/tangle-dapp/src/components/Sidebar/useSidebarProps.ts
+++ b/apps/tangle-dapp/src/components/Sidebar/useSidebarProps.ts
@@ -2,9 +2,11 @@ import useNetworkStore from '@tangle-network/tangle-shared-ui/context/useNetwork
 import { useMemo } from 'react';
 
 import getSidebarProps from './sidebarProps';
+import useNetworkFeatures from '../../hooks/useNetworkFeatures';
 
 export default function useSidebarProps() {
   const { network } = useNetworkStore();
+  const networkFeatures = useNetworkFeatures();
 
   const sidebarProps = useMemo(
     () =>
@@ -12,11 +14,13 @@ export default function useSidebarProps() {
         polkadotJsDashboardUrl: network.polkadotJsDashboardUrl,
         nativeExplorerUrl: network.explorerUrl,
         evmExplorerUrl: network.evmExplorerUrl,
+        networkFeatures,
       }),
     [
       network.evmExplorerUrl,
       network.explorerUrl,
       network.polkadotJsDashboardUrl,
+      networkFeatures,
     ],
   );
 

--- a/apps/tangle-dapp/src/components/account/Actions.tsx
+++ b/apps/tangle-dapp/src/components/account/Actions.tsx
@@ -18,7 +18,8 @@ import useAirdropEligibility from '../../data/claims/useAirdropEligibility';
 import useTotalPayoutRewards from '../../data/nomination/useTotalPayoutRewards';
 import useVestingInfo from '../../data/vesting/useVestingInfo';
 import useVestTx from '../../data/vesting/useVestTx';
-import { PagePath, StaticSearchQueryPath } from '../../types';
+import useNetworkFeatures from '../../hooks/useNetworkFeatures';
+import { NetworkFeature, PagePath, StaticSearchQueryPath } from '../../types';
 import formatTangleBalance from '../../utils/formatTangleBalance';
 import ActionItem from './ActionItem';
 import WithdrawEvmBalanceAction from './WithdrawEvmBalanceAction';
@@ -31,6 +32,7 @@ const Actions: FC = () => {
   const { transferable: transferableBalance } = useBalances();
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isCreditsModalOpen, setIsCreditsModalOpen] = useState(false);
+  const networkFeatures = useNetworkFeatures();
 
   const { isEligible: isAirdropEligible } = useAirdropEligibility();
 
@@ -72,12 +74,14 @@ const Actions: FC = () => {
         Icon={CoinsStackedLineIcon}
       />
 
-      <ActionItem
-        label="Faucet"
-        tooltip="Request testnet assets from the Tangle Network Faucet"
-        Icon={FaucetIcon}
-        externalHref={TANGLE_FAUCET_URL}
-      />
+      {networkFeatures.includes(NetworkFeature.Faucet) && (
+        <ActionItem
+          label="Faucet"
+          tooltip="Request testnet assets from the Tangle Network Faucet"
+          Icon={FaucetIcon}
+          externalHref={TANGLE_FAUCET_URL}
+        />
+      )}
 
       <ActionItem
         hasNotificationDot={isPayoutsAvailable}

--- a/apps/tangle-dapp/src/components/account/ProtocolStatisticCard/VaultsHightlightCard.tsx
+++ b/apps/tangle-dapp/src/components/account/ProtocolStatisticCard/VaultsHightlightCard.tsx
@@ -36,11 +36,12 @@ const VaultsHightlightCard = ({
   isLoading,
   ...props
 }: Props) => {
-  // Get first 5 vaults with the highest tvl, then ID
+  // Get first 5 vaults with the highest tvl, then ID (excluding ETH vault ID: 2 since the image is not available)
   const sortedVaults = useMemo(
     () =>
       vaults
         ?.slice()
+        .filter((vault) => vault.id !== 2) // Filter out ETH vault
         .sort((a, b) => {
           if (a.tvl === undefined && b.tvl === undefined) {
             return a.id - b.id;
@@ -189,7 +190,7 @@ const VaultHighlight = ({
       <Typography
         variant="body4"
         fw="bold"
-        className="uppercase text-blue-60 dark:text-blue-40"
+        className="uppercase text-blue-40 dark:text-blue-40"
       >
         Featured Vault
       </Typography>
@@ -197,7 +198,7 @@ const VaultHighlight = ({
       <Typography
         variant="h4"
         fw="bold"
-        className="text-mono-180 dark:text-mono-0"
+        className="text-mono-0 dark:text-mono-0"
       >
         {vaultName}
       </Typography>
@@ -208,8 +209,8 @@ const VaultHighlight = ({
           result={vaultTvl || EMPTY_VALUE_PLACEHOLDER}
           isLoading={isVaultTvlLoading}
           error={null}
-          labelClassName="text-mono-180 dark:text-mono-60"
-          valueClassName="text-mono-200 dark:text-mono-0"
+          labelClassName="text-mono-0 dark:text-mono-60"
+          valueClassName="text-mono-0 dark:text-mono-0"
         />
 
         <StatsItem
@@ -221,8 +222,8 @@ const VaultHighlight = ({
           }
           isLoading={isVaultParticipantsLoading}
           error={vaultParticipantsError}
-          labelClassName="text-mono-180 dark:text-mono-60"
-          valueClassName="text-mono-200 dark:text-mono-0"
+          labelClassName="text-mono-0 dark:text-mono-60"
+          valueClassName="text-mono-0 dark:text-mono-0"
         />
       </div>
     </div>

--- a/apps/tangle-dapp/src/constants/restake.ts
+++ b/apps/tangle-dapp/src/constants/restake.ts
@@ -1,6 +1,8 @@
 import { PresetTypedChainId } from '@tangle-network/dapp-types/ChainId';
 
 export const SUPPORTED_RESTAKE_DEPOSIT_TYPED_CHAIN_IDS = [
+  PresetTypedChainId.TangleMainnetNative,
+  PresetTypedChainId.TangleMainnetEVM,
   PresetTypedChainId.TangleTestnetNative,
   PresetTypedChainId.TangleTestnetEVM,
   PresetTypedChainId.TangleLocalNative,

--- a/apps/tangle-dapp/src/containers/restaking/WithdrawModal.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/WithdrawModal.tsx
@@ -88,10 +88,13 @@ const WithdrawModal = ({
           return null;
         }
 
+        const displayName =
+          assetId === '0' ? 'Tangle Network Token' : asset.metadata.name;
+
         return (
           <AssetListItem
             assetId={assetId}
-            name={asset.metadata.name}
+            name={displayName}
             symbol={asset.metadata.symbol}
             balance={new BN(amount.toString())}
             decimals={asset.metadata.decimals}

--- a/apps/tangle-dapp/src/data/restake/RestakeAbiBase.ts
+++ b/apps/tangle-dapp/src/data/restake/RestakeAbiBase.ts
@@ -31,6 +31,7 @@ abstract class RestakeApiBase {
     assetId: RestakeAssetId,
     amount: BN,
     blueprintSelection?: BN[],
+    isNominatedAsset?: boolean,
   ): Promise<void>;
 
   abstract undelegate(

--- a/apps/tangle-dapp/src/data/restake/RestakeSubstrateApi.ts
+++ b/apps/tangle-dapp/src/data/restake/RestakeSubstrateApi.ts
@@ -80,20 +80,30 @@ class RestakeSubstrateApi extends RestakeApiBase {
     assetId: RestakeAssetId,
     amount: BN,
     blueprintSelection?: BN[],
+    isNominatedAsset?: boolean,
   ) {
-    const assetIdEnum = isEvmAddress(assetId)
-      ? { Erc20: assetId }
-      : { Custom: new BN(assetId) };
-
     const blueprintSelectionEnum = { Fixed: blueprintSelection ?? [] };
 
-    // TODO: Evm address & lock multiplier.
-    const extrinsic = this.api.tx.multiAssetDelegation.delegate(
-      operatorAddress,
-      assetIdEnum,
-      amount,
-      blueprintSelectionEnum,
-    );
+    let extrinsic;
+
+    if (isNominatedAsset) {
+      extrinsic = this.api.tx.multiAssetDelegation.delegateNomination(
+        operatorAddress,
+        amount,
+        blueprintSelectionEnum,
+      );
+    } else {
+      const assetIdEnum = isEvmAddress(assetId)
+        ? { Erc20: assetId }
+        : { Custom: new BN(assetId) };
+
+      extrinsic = this.api.tx.multiAssetDelegation.delegate(
+        operatorAddress,
+        assetIdEnum,
+        amount,
+        blueprintSelectionEnum,
+      );
+    }
 
     return this.submitTx(TxName.RESTAKE_DELEGATE, extrinsic);
   }

--- a/apps/tangle-dapp/src/pages/restake/deposit/DepositForm.tsx
+++ b/apps/tangle-dapp/src/pages/restake/deposit/DepositForm.tsx
@@ -263,10 +263,13 @@ const DepositForm: FC<Props> = ({
             renderItem={(asset) => {
               const balance = asset.balance ?? BN_ZERO;
 
+              const displayName =
+                asset.id === '0' ? 'Tangle Network Token' : asset.metadata.name;
+
               return (
                 <AssetListItem
                   assetId={asset.id}
-                  name={asset.metadata.name}
+                  name={displayName}
                   symbol={asset.metadata.symbol}
                   balance={balance}
                   decimals={asset.metadata.decimals}

--- a/libs/dapp-config/src/chains/substrate/index.tsx
+++ b/libs/dapp-config/src/chains/substrate/index.tsx
@@ -5,7 +5,6 @@ import {
 import { ChainType } from '@tangle-network/dapp-types/TypedChainId';
 import {
   TANGLE_LOCAL_WS_RPC_ENDPOINT,
-  TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
   TANGLE_MAINNET_NATIVE_EXPLORER_URL,
   TANGLE_MAINNET_NATIVE_TOKEN_SYMBOL,
   TANGLE_MAINNET_WS_RPC_ENDPOINT,
@@ -39,10 +38,7 @@ export const chainsConfig = {
     rpcUrls: {
       default: {
         http: [],
-        webSocket: [
-          TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
-          TANGLE_MAINNET_WS_RPC_ENDPOINT,
-        ],
+        webSocket: [TANGLE_MAINNET_WS_RPC_ENDPOINT],
       },
     },
   },

--- a/libs/dapp-config/src/constants/tangle.ts
+++ b/libs/dapp-config/src/constants/tangle.ts
@@ -4,17 +4,11 @@ import getPolkadotJsDashboardUrl from '../utils/getPolkadotJsDashboardUrl';
 
 // MAINNET
 export const TANGLE_MAINNET_WS_RPC_ENDPOINT = 'wss://rpc.tangle.tools';
-export const TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT =
-  'wss://tangle-mainnet-rpc.dwellir.com';
-
 export const TANGLE_MAINNET_HTTP_RPC_ENDPOINT = 'https://rpc.tangle.tools';
-export const TANGLE_MAINNET_HTTP_DWELLIR_RPC_ENDPOINT =
-  'https://tangle-mainnet-rpc.dwellir.com';
 
 export const TANGLE_MAINNET_POLKADOT_JS_DASHBOARD_URL =
   getPolkadotJsDashboardUrl(TANGLE_MAINNET_WS_RPC_ENDPOINT);
-export const TANGLE_MAINNET_NATIVE_EXPLORER_URL =
-  'https://tangle.statescan.io/';
+export const TANGLE_MAINNET_NATIVE_EXPLORER_URL = `https://polkadot.js.org/apps/?rpc=${TANGLE_MAINNET_WS_RPC_ENDPOINT}#/explorer`;
 export const TANGLE_MAINNET_EVM_EXPLORER_URL = 'https://explorer.tangle.tools/';
 export const TANGLE_MAINNET_NATIVE_TOKEN_SYMBOL = 'TNT';
 

--- a/libs/tangle-shared-ui/src/types/restake.ts
+++ b/libs/tangle-shared-ui/src/types/restake.ts
@@ -145,4 +145,6 @@ export type RestakeAssetTableItem = {
   symbol: string;
   balance: BN;
   decimals: number;
+  label?: string;
+  labelColor?: 'green' | 'purple' | 'blue' | 'red' | 'yellow';
 };

--- a/libs/tangle-shared-ui/src/utils/restake/getAssetType.ts
+++ b/libs/tangle-shared-ui/src/utils/restake/getAssetType.ts
@@ -1,0 +1,45 @@
+import { NATIVE_ASSET_ID } from '../../constants/restaking';
+import { RestakeAssetId } from '../../types';
+
+/**
+ * Enum representing the different types of restake assets
+ */
+export enum RestakeAssetType {
+  /** Regular asset that was deposited directly into multiAssetDelegation pallet */
+  REGULAR = 'regular',
+  /** Native asset that was nominated to validators and can be delegated */
+  NOMINATED = 'nominated',
+}
+
+/**
+ * Determines the type of a restake asset based on its ID and source
+ *
+ * @param assetId - The asset ID to check
+ * @param isFromNomination - Whether this asset comes from nomination (staking) balance
+ * @returns The asset type (REGULAR or NOMINATED)
+ */
+export const getRestakeAssetType = (
+  assetId: RestakeAssetId,
+  isFromNomination: boolean,
+): RestakeAssetType => {
+  if (assetId === NATIVE_ASSET_ID && isFromNomination) {
+    return RestakeAssetType.NOMINATED;
+  }
+
+  return RestakeAssetType.REGULAR;
+};
+
+/**
+ * Checks if an asset is nominated (from staking/nomination)
+ */
+export const isNominatedAsset = (
+  assetId: RestakeAssetId,
+  isFromNomination: boolean,
+): boolean => {
+  return (
+    getRestakeAssetType(assetId, isFromNomination) ===
+    RestakeAssetType.NOMINATED
+  );
+};
+
+export default getRestakeAssetType;

--- a/libs/ui-components/src/constants/networks.ts
+++ b/libs/ui-components/src/constants/networks.ts
@@ -1,9 +1,7 @@
 import { EVMChainId, SubstrateChainId } from '@tangle-network/dapp-types';
 import {
   TANGLE_MAINNET_WS_RPC_ENDPOINT,
-  TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
   TANGLE_MAINNET_HTTP_RPC_ENDPOINT,
-  TANGLE_MAINNET_HTTP_DWELLIR_RPC_ENDPOINT,
   TANGLE_MAINNET_POLKADOT_JS_DASHBOARD_URL,
   TANGLE_MAINNET_NATIVE_EXPLORER_URL,
   TANGLE_MAINNET_EVM_EXPLORER_URL,
@@ -93,15 +91,9 @@ export const TANGLE_MAINNET_NETWORK = {
   name: 'Tangle Mainnet',
   tokenSymbol: TANGLE_MAINNET_NATIVE_TOKEN_SYMBOL,
   nodeType: 'standalone',
-  wsRpcEndpoints: [
-    TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
-    TANGLE_MAINNET_WS_RPC_ENDPOINT,
-  ],
-  httpRpcEndpoints: [
-    TANGLE_MAINNET_HTTP_DWELLIR_RPC_ENDPOINT,
-    TANGLE_MAINNET_HTTP_RPC_ENDPOINT,
-  ],
-  archiveRpcEndpoint: TANGLE_MAINNET_WS_DWELLIR_RPC_ENDPOINT,
+  wsRpcEndpoints: [TANGLE_MAINNET_WS_RPC_ENDPOINT],
+  httpRpcEndpoints: [TANGLE_MAINNET_HTTP_RPC_ENDPOINT],
+  archiveRpcEndpoint: TANGLE_MAINNET_WS_RPC_ENDPOINT,
   polkadotJsDashboardUrl: TANGLE_MAINNET_POLKADOT_JS_DASHBOARD_URL,
   explorerUrl: TANGLE_MAINNET_NATIVE_EXPLORER_URL,
   evmExplorerUrl: TANGLE_MAINNET_EVM_EXPLORER_URL,
@@ -111,7 +103,7 @@ export const TANGLE_MAINNET_NETWORK = {
     if (isEvmAddress(address)) {
       return `${TANGLE_MAINNET_EVM_EXPLORER_URL}/address/${address}`;
     } else {
-      return `${TANGLE_MAINNET_NATIVE_EXPLORER_URL}/#/accounts/${address}`;
+      return `${TANGLE_MAINNET_NATIVE_EXPLORER_URL}/accounts`;
     }
   },
 
@@ -122,7 +114,7 @@ export const TANGLE_MAINNET_NETWORK = {
 
     return blockHash === undefined
       ? null
-      : `${TANGLE_MAINNET_NATIVE_EXPLORER_URL}/#/blocks/${blockHash}`;
+      : `${TANGLE_MAINNET_NATIVE_EXPLORER_URL}/query/${blockHash}`;
   },
 } as const satisfies Network;
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@swc/jest": "~0.2.37",
     "@tailwindcss/forms": "^0.5.10",
     "@tangle-network/tangle-restaking-types": "0.1.0",
-    "@tangle-network/tangle-substrate-types": "^0.9.32",
+    "@tangle-network/tangle-substrate-types": "^0.9.34",
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/dom": "^10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14173,16 +14173,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tangle-network/tangle-substrate-types@npm:^0.9.32":
-  version: 0.9.32
-  resolution: "@tangle-network/tangle-substrate-types@npm:0.9.32"
+"@tangle-network/tangle-substrate-types@npm:^0.9.34":
+  version: 0.9.34
+  resolution: "@tangle-network/tangle-substrate-types@npm:0.9.34"
   dependencies:
     "@polkadot/api": "npm:^13.2.1"
     "@polkadot/typegen": "npm:^13.2.1"
     "@polkadot/types": "npm:^13.2.1"
     ecpair: "npm:^2.1.0"
     tiny-secp256k1: "npm:^2.2.3"
-  checksum: 10c0/f39c37af7692b15dac022dcc222b68dadbca23a0e977fe2c8f8f523740d85422b94cf737a450e0616f106340446a7708b6a85fc1aa076691ac48dd483ec39027
+  checksum: 10c0/419223d7c962123d7ea002d05137e62d65452f5279f22443459a8c6867761948cc788d29356fd1186cc926492902e8288ebfa5c17fa653dac48ebc3b00ddc8c9
   languageName: node
   linkType: hard
 
@@ -34025,7 +34025,7 @@ __metadata:
     "@tailwindcss/forms": "npm:^0.5.10"
     "@tangle-network/evm-contract-metadata": "npm:^1.3.0"
     "@tangle-network/tangle-restaking-types": "npm:0.1.0"
-    "@tangle-network/tangle-substrate-types": "npm:^0.9.32"
+    "@tangle-network/tangle-substrate-types": "npm:^0.9.34"
     "@tanstack/match-sorter-utils": "npm:^8.19.4"
     "@tanstack/react-query": "npm:^5.74.3"
     "@tanstack/react-table": "npm:^8.21.3"


### PR DESCRIPTION
## Summary of changes

- Updated `@tangle-network/tangle-substrate-types` to `0.9.34`
- Removed Liquid Staking and Claims from sidebar
- Removed testnet faucet when connected to mainnet
- Added visual badges to distinguish between `Nominated` (purple) and `Deposited` (green) TNT assets across all restaking flows
- Enhanced logic to properly handle both nominated and deposited TNT balances
- Consistent asset naming across all flows
- Enhanced delegation calls to use delegateNomination for nominated assets vs standard delegate for deposited assets
- Removed Dwellir RPC endpoints
- Show operator names if available in operator modals
- Other minor fixes and improvements

### Proposed area of change

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [x] `apps/leaderboard`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Screenshots & Screen Recordings

<img width="1242" height="690" alt="CleanShot 2025-08-04 at 16 03 09@2x" src="https://github.com/user-attachments/assets/4387abbf-d5e1-4058-8027-7b25c6b9d7d1" />