### PR TITLE
chore(tangle-dapp): Restake Undelegate & Withdraw Improvements

### DIFF
--- a/apps/tangle-dapp/src/components/Lists/AssetListItem.tsx
+++ b/apps/tangle-dapp/src/components/Lists/AssetListItem.tsx
@@ -12,6 +12,7 @@ import { makeExplorerUrl } from '@tangle-network/api-provider-environment/transa
 import { useActiveChain } from '@tangle-network/api-provider-environment/hooks/useActiveChain';
 import LogoListItem from './LogoListItem';
 import { BN } from '@polkadot/util';
+import { getAssetLabelColorClasses } from '../../utils/getAssetLabelColorClasses';
 
 type Props = {
   assetId: string;
@@ -99,13 +100,7 @@ const AssetListItem = ({
             {name} ({symbol})
           </span>
           <span
-            className={`px-2 py-1 rounded text-xs font-medium ${
-              labelColor === 'green'
-                ? 'bg-green-100 text-mono-0 dark:bg-green-900 dark:text-mono-0'
-                : labelColor === 'purple'
-                  ? 'bg-purple-900 text-mono-0 dark:bg-purple-900 dark:text-mono-0'
-                  : 'bg-blue-900 text-mono-0 dark:bg-blue-900 dark:text-mono-0'
-            }`}
+            className={`px-2 py-1 rounded text-xs font-medium ${getAssetLabelColorClasses(labelColor)}`}
           >
             {label}
           </span>

--- a/apps/tangle-dapp/src/components/Lists/LogoListItem.tsx
+++ b/apps/tangle-dapp/src/components/Lists/LogoListItem.tsx
@@ -9,7 +9,7 @@ type Props = {
   leftUpperContent: ReactNode | string;
   leftBottomContent?: ReactNode | string;
   leftBottomContentTwo?: ReactNode | string;
-  rightUpperText?: string;
+  rightUpperText?: string | ReactNode;
   rightBottomText?: string;
 };
 
@@ -69,12 +69,18 @@ const LogoListItem: FC<Props> = ({
 
       {(rightUpperText !== undefined || rightBottomText !== undefined) && (
         <div className="flex flex-col items-end justify-center">
-          <Typography
-            variant="body1"
-            className="text-mono-200 dark:text-mono-0"
-          >
-            {rightUpperText ?? EMPTY_VALUE_PLACEHOLDER}
-          </Typography>
+          {typeof rightUpperText === 'string' ? (
+            <Typography
+              variant="body1"
+              className="text-mono-200 dark:text-mono-0"
+            >
+              {rightUpperText ?? EMPTY_VALUE_PLACEHOLDER}
+            </Typography>
+          ) : (
+            <div className="text-mono-200 dark:text-mono-0">
+              {rightUpperText ?? EMPTY_VALUE_PLACEHOLDER}
+            </div>
+          )}
 
           {rightBottomText !== undefined && (
             <Typography

--- a/apps/tangle-dapp/src/components/Lists/OperatorListItem.tsx
+++ b/apps/tangle-dapp/src/components/Lists/OperatorListItem.tsx
@@ -10,7 +10,7 @@ import LogoListItem from './LogoListItem';
 type Props = {
   accountAddress: SubstrateAddress;
   identity?: string;
-  rightUpperText?: string;
+  rightUpperText?: string | React.ReactNode;
   rightBottomText?: string;
 };
 

--- a/apps/tangle-dapp/src/constants/index.ts
+++ b/apps/tangle-dapp/src/constants/index.ts
@@ -81,6 +81,7 @@ export enum TxName {
   RESTAKE_NATIVE_DELEGATE = 'restake delegate nomination',
   RESTAKE_NATIVE_UNSTAKE = 'restake undelegate native',
   RESTAKE_NATIVE_UNSTAKE_EXECUTE = 'restake execute undelegate native',
+  RESTAKE_DEPOSITED_UNSTAKE_EXECUTE = 'restake execute undelegate deposited',
   RESTAKE_NATIVE_UNSTAKE_CANCEL = 'restake cancel undelegate native',
 }
 

--- a/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
@@ -1,0 +1,182 @@
+import { DelegatorInfo } from '@tangle-network/tangle-shared-ui/types/restake';
+import type { IdentityType } from '@tangle-network/tangle-shared-ui/utils/polkadot/identity';
+import { useMemo } from 'react';
+import ListModal from '@tangle-network/tangle-shared-ui/components/ListModal';
+import { formatUnits } from 'viem';
+import OperatorListItem from '../../components/Lists/OperatorListItem';
+import {
+  AmountFormatStyle,
+  formatDisplayAmount,
+} from '@tangle-network/ui-components';
+import { BN } from '@polkadot/util';
+import useRestakeAssets from '@tangle-network/tangle-shared-ui/data/restake/useRestakeAssets';
+import filterBy from '@tangle-network/tangle-shared-ui/utils/filterBy';
+import { Typography } from '@tangle-network/ui-components/typography/Typography';
+import useRestakeCurrentRound from '../../data/restake/useRestakeCurrentRound';
+
+type Props = {
+  delegatorInfo: DelegatorInfo | null;
+  operatorIdentities?: Map<string, IdentityType | null> | null;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+
+  onItemSelected: (
+    item: DelegatorInfo['delegations'][number] & {
+      formattedAmount: string;
+      isReadyToUnstake: boolean;
+      undelegatableAmount: bigint;
+    },
+  ) => void;
+};
+
+const calculateUndelegatableAmount = (
+  delegation: DelegatorInfo['delegations'][number],
+  unstakeRequests: DelegatorInfo['unstakeRequests'],
+): bigint => {
+  const pendingUnstakeAmount = unstakeRequests
+    .filter(
+      (req) =>
+        req.operatorAccountId === delegation.operatorAccountId &&
+        req.assetId === delegation.assetId,
+    )
+    .reduce((sum, req) => sum + req.amount, BigInt(0));
+
+  const availableAmount = delegation.amountBonded - pendingUnstakeAmount;
+  return availableAmount > BigInt(0) ? availableAmount : BigInt(0);
+};
+
+const SelectOperatorModalEnhanced = ({
+  delegatorInfo,
+  isOpen,
+  setIsOpen,
+  onItemSelected,
+  operatorIdentities,
+}: Props) => {
+  const { assets } = useRestakeAssets();
+  const { result: currentRound } = useRestakeCurrentRound();
+
+  const availableDelegations = useMemo(() => {
+    if (!Array.isArray(delegatorInfo?.delegations)) {
+      return [];
+    }
+
+    return delegatorInfo.delegations
+      .map((delegation) => {
+        const undelegatableAmount = calculateUndelegatableAmount(
+          delegation,
+          delegatorInfo.unstakeRequests || [],
+        );
+
+        const pendingRequest = delegatorInfo.unstakeRequests?.find(
+          (req) =>
+            req.operatorAccountId === delegation.operatorAccountId &&
+            req.assetId === delegation.assetId,
+        );
+
+        const isRequestReady =
+          !pendingRequest ||
+          (currentRound !== null && pendingRequest.requestedRound <= currentRound) ||
+          false;
+
+        return {
+          ...delegation,
+          undelegatableAmount,
+          pendingUnstakeRequest: pendingRequest,
+          isRequestReady,
+        };
+      })
+      .filter((item) => item.undelegatableAmount > BigInt(0));
+  }, [delegatorInfo, currentRound]);
+
+  return (
+    <ListModal
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      searchInputId="restake-undelegate-operator-search"
+      searchPlaceholder="Search operators..."
+      items={availableDelegations}
+      title="Select Operator to Unstake"
+      titleWhenEmpty="No Delegations Found"
+      descriptionWhenEmpty="No delegations available for unstaking. You may need to wait for pending unstake requests to complete or delegate assets first."
+      onSelect={(item) => {
+        const asset = assets?.get(item.assetId);
+
+        if (asset === undefined) {
+          return;
+        }
+
+        const fmtAmount = formatUnits(
+          item.undelegatableAmount,
+          asset.metadata.decimals,
+        );
+
+        onItemSelected({
+          ...item,
+          formattedAmount: fmtAmount,
+          isReadyToUnstake: item.isRequestReady,
+          undelegatableAmount: item.undelegatableAmount,
+        });
+      }}
+      filterItem={(delegation, query) => {
+        const asset = assets?.get(delegation.assetId);
+
+        if (asset === undefined) {
+          return false;
+        }
+
+        const assetSymbol = asset.metadata.symbol;
+
+        const identityName = operatorIdentities?.get(
+          delegation.operatorAccountId,
+        )?.name;
+
+        return filterBy(query, [
+          delegation.operatorAccountId,
+          assetSymbol,
+          identityName,
+        ]);
+      }}
+      renderItem={(item) => {
+        const asset = assets?.get(item.assetId);
+
+        if (asset === undefined) {
+          return null;
+        }
+
+        const fmtAmount = formatDisplayAmount(
+          new BN(item.undelegatableAmount.toString()),
+          asset.metadata.decimals,
+          AmountFormatStyle.SHORT,
+        );
+
+        const identityName = operatorIdentities?.get(
+          item.operatorAccountId,
+        )?.name;
+
+        const assetLabel = item.isNomination ? 'Nominated' : 'Deposited';
+        
+        const statusText = item.pendingUnstakeRequest && !item.isRequestReady
+          ? `Waiting (Round ${item.pendingUnstakeRequest.requestedRound})`
+          : 'Available';
+
+        return (
+          <div className="flex items-center justify-between w-full">
+            <OperatorListItem
+              accountAddress={item.operatorAccountId}
+              identity={identityName ?? undefined}
+              rightUpperText={`${fmtAmount} ${asset.metadata.symbol}`}
+              rightBottomText={`${assetLabel} • ${statusText}`}
+            />
+            {item.pendingUnstakeRequest && currentRound && !item.isRequestReady && (
+              <Typography variant="body2" className="text-mono-100 ml-2">
+                {item.pendingUnstakeRequest.requestedRound - currentRound} rounds left
+              </Typography>
+            )}
+          </div>
+        );
+      }}
+    />
+  );
+};
+
+export default SelectOperatorModalEnhanced;

--- a/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
@@ -145,7 +145,7 @@ const SelectOperatorModalEnhanced = ({
           return null;
         }
 
-        const fmtAmount = formatDisplayAmount(
+        const fmtAvailableAmount = formatDisplayAmount(
           new BN(item.undelegatableAmount.toString()),
           asset.metadata.decimals,
           AmountFormatStyle.SHORT,
@@ -156,19 +156,30 @@ const SelectOperatorModalEnhanced = ({
         )?.name;
 
         const assetLabel = item.isNomination ? 'Nominated' : 'Deposited';
-
-        const statusText =
-          item.pendingUnstakeRequest && !item.isRequestReady
-            ? `Waiting (Round ${item.pendingUnstakeRequest.requestedRound})`
-            : 'Available';
+        const labelColor = item.isNomination ? 'purple' : 'green';
 
         return (
           <div className="flex items-center justify-between w-full">
             <OperatorListItem
               accountAddress={item.operatorAccountId}
               identity={identityName ?? undefined}
-              rightUpperText={`${fmtAmount} ${asset.metadata.symbol}`}
-              rightBottomText={`${assetLabel} • ${statusText}`}
+              rightUpperText={
+                <div className="flex items-center gap-2">
+                  <span>{fmtAvailableAmount} {asset.metadata.symbol}</span>
+                  <span
+                    className={`px-2 py-1 rounded text-xs font-medium ${
+                      labelColor === 'green'
+                        ? 'bg-green-100 text-mono-0 dark:bg-green-900 dark:text-mono-0'
+                        : labelColor === 'purple'
+                          ? 'bg-purple-900 text-mono-0 dark:bg-purple-900 dark:text-mono-0'
+                          : 'bg-blue-900 text-mono-0 dark:bg-blue-900 dark:text-mono-0'
+                    }`}
+                  >
+                    {assetLabel}
+                  </span>
+                </div>
+              }
+              rightBottomText="Balance"
             />
             {item.pendingUnstakeRequest &&
               currentRound &&

--- a/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
@@ -37,7 +37,8 @@ const calculateUndelegatableAmount = (
     .filter(
       (req) =>
         req.operatorAccountId === delegation.operatorAccountId &&
-        req.assetId === delegation.assetId,
+        req.assetId === delegation.assetId &&
+        req.isNomination === delegation.isNomination,
     )
     .reduce((sum, req) => sum + req.amount, BigInt(0));
 

--- a/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
@@ -75,7 +75,8 @@ const SelectOperatorModalEnhanced = ({
 
         const isRequestReady =
           !pendingRequest ||
-          (currentRound !== null && pendingRequest.requestedRound <= currentRound) ||
+          (currentRound !== null &&
+            pendingRequest.requestedRound <= currentRound) ||
           false;
 
         return {
@@ -154,10 +155,11 @@ const SelectOperatorModalEnhanced = ({
         )?.name;
 
         const assetLabel = item.isNomination ? 'Nominated' : 'Deposited';
-        
-        const statusText = item.pendingUnstakeRequest && !item.isRequestReady
-          ? `Waiting (Round ${item.pendingUnstakeRequest.requestedRound})`
-          : 'Available';
+
+        const statusText =
+          item.pendingUnstakeRequest && !item.isRequestReady
+            ? `Waiting (Round ${item.pendingUnstakeRequest.requestedRound})`
+            : 'Available';
 
         return (
           <div className="flex items-center justify-between w-full">
@@ -167,11 +169,14 @@ const SelectOperatorModalEnhanced = ({
               rightUpperText={`${fmtAmount} ${asset.metadata.symbol}`}
               rightBottomText={`${assetLabel} • ${statusText}`}
             />
-            {item.pendingUnstakeRequest && currentRound && !item.isRequestReady && (
-              <Typography variant="body2" className="text-mono-100 ml-2">
-                {item.pendingUnstakeRequest.requestedRound - currentRound} rounds left
-              </Typography>
-            )}
+            {item.pendingUnstakeRequest &&
+              currentRound &&
+              !item.isRequestReady && (
+                <Typography variant="body2" className="text-mono-100 ml-2">
+                  {item.pendingUnstakeRequest.requestedRound - currentRound}{' '}
+                  rounds left
+                </Typography>
+              )}
           </div>
         );
       }}

--- a/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/SelectOperatorModalEnhanced.tsx
@@ -165,7 +165,9 @@ const SelectOperatorModalEnhanced = ({
               identity={identityName ?? undefined}
               rightUpperText={
                 <div className="flex items-center gap-2">
-                  <span>{fmtAvailableAmount} {asset.metadata.symbol}</span>
+                  <span>
+                    {fmtAvailableAmount} {asset.metadata.symbol}
+                  </span>
                   <span
                     className={`px-2 py-1 rounded text-xs font-medium ${
                       labelColor === 'green'

--- a/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTable.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTable.tsx
@@ -43,6 +43,7 @@ export type UnstakeRequestTableRow = {
   sessionDurationMs: number;
   operatorAccountId: SubstrateAddress;
   operatorIdentityName?: string;
+  isNomination: boolean;
 };
 
 const COLUMN_HELPER = createColumnHelper<UnstakeRequestTableRow>();
@@ -71,8 +72,23 @@ const COLUMNS = [
   COLUMN_HELPER.accessor('amount', {
     header: () => <TableCell>Amount</TableCell>,
     cell: (props) => (
-      <TableCell fw="normal" className="text-mono-200 dark:text-mono-0">
-        {props.getValue()} {props.row.original.assetSymbol}
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <Typography variant="body2" className="font-bold">
+            {props.getValue()}
+          </Typography>
+          {props.row.original.assetId === '0' && (
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                props.row.original.isNomination
+                  ? 'bg-purple-900 text-mono-0'
+                  : 'bg-green-100 text-mono-0 dark:bg-green-900'
+              }`}
+            >
+              {props.row.original.isNomination ? 'Nominated' : 'Deposited'}
+            </span>
+          )}
+        </div>
       </TableCell>
     ),
   }),
@@ -129,7 +145,7 @@ const UnstakeRequestTable: FC<Props> = ({
     }
 
     return unstakeRequests.flatMap(
-      ({ assetId, amount, requestedRound, operatorAccountId }) => {
+      ({ assetId, amount, requestedRound, operatorAccountId, isNomination }) => {
         const asset = assets?.get(assetId);
 
         // Skip requests that are lacking metadata.
@@ -159,6 +175,7 @@ const UnstakeRequestTable: FC<Props> = ({
           operatorAccountId,
           operatorIdentityName:
             operatorIdentities.get(operatorAccountId)?.name ?? undefined,
+          isNomination,
         } satisfies UnstakeRequestTableRow;
       },
     );

--- a/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTable.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTable.tsx
@@ -145,7 +145,13 @@ const UnstakeRequestTable: FC<Props> = ({
     }
 
     return unstakeRequests.flatMap(
-      ({ assetId, amount, requestedRound, operatorAccountId, isNomination }) => {
+      ({
+        assetId,
+        amount,
+        requestedRound,
+        operatorAccountId,
+        isNomination,
+      }) => {
         const asset = assets?.get(assetId);
 
         // Skip requests that are lacking metadata.

--- a/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTableActions.tsx
+++ b/apps/tangle-dapp/src/containers/restaking/UnstakeRequestTableActions.tsx
@@ -46,34 +46,32 @@ const UnstakeRequestTableActions: FC<Props> = ({
       return;
     }
 
-    const unstakeRequests = selectedRequests.map(
-      ({ amountRaw, operatorAccountId, assetId }) => {
-        return {
-          amount: new BN(amountRaw.toString()),
-          assetId,
-          operatorAddress: operatorAccountId,
-        };
-      },
+    const nominatedUnstakeRequests = selectedRequests.filter(
+      (request) => request.isNomination === true,
     );
 
-    const nativeUnstakeRequests = unstakeRequests.filter(
-      (request) => request.assetId === NATIVE_ASSET_ID,
+    const depositedUnstakeRequests = selectedRequests.filter(
+      (request) => request.isNomination !== true,
     );
 
-    const nonNativeUnstakeRequests = unstakeRequests.filter(
-      (request) => request.assetId !== NATIVE_ASSET_ID,
+    const depositedUnstakeRequestsForApi = depositedUnstakeRequests.map(
+      ({ amountRaw, operatorAccountId, assetId }) => ({
+        amount: new BN(amountRaw.toString()),
+        assetId,
+        operatorAddress: operatorAccountId,
+      }),
     );
 
     setIsTransacting(true);
 
-    if (nonNativeUnstakeRequests.length > 0) {
+    if (depositedUnstakeRequestsForApi.length > 0) {
       if (!restakeApi) return;
-      await restakeApi.cancelUndelegate(nonNativeUnstakeRequests);
+      await restakeApi.cancelUndelegate(depositedUnstakeRequestsForApi);
     }
 
-    if (nativeUnstakeRequests.length > 0) {
+    if (nominatedUnstakeRequests.length > 0) {
       await executeCancel(
-        nativeUnstakeRequests.map((request) => request.operatorAddress),
+        nominatedUnstakeRequests.map((request) => request.operatorAccountId),
       );
     }
 

--- a/apps/tangle-dapp/src/data/restake/useDepositedRestakeUnstakeExecuteTx.ts
+++ b/apps/tangle-dapp/src/data/restake/useDepositedRestakeUnstakeExecuteTx.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import { TxName } from '../../constants';
+import { PrecompileAddress } from '@tangle-network/tangle-shared-ui/constants/evmPrecompiles';
+import useAgnosticTx from '@tangle-network/tangle-shared-ui/hooks/useAgnosticTx';
+import { EvmTxFactory } from '@tangle-network/tangle-shared-ui/hooks/useEvmPrecompileCall';
+import { SubstrateTxFactory } from '@tangle-network/tangle-shared-ui/hooks/useSubstrateTx';
+import RESTAKING_PRECOMPILE_ABI from '@tangle-network/tangle-shared-ui/abi/restaking';
+import { SUCCESS_MESSAGES } from '../../hooks/useTxNotification';
+
+type Context = void;
+
+const useDepositedRestakeUnstakeExecuteTx = () => {
+  const evmTxFactory: EvmTxFactory<
+    typeof RESTAKING_PRECOMPILE_ABI,
+    'executeDelegatorUnstake',
+    Context
+  > = useCallback(() => {
+    return {
+      functionName: 'executeDelegatorUnstake',
+      arguments: [],
+    };
+  }, []);
+
+  const substrateTxFactory: SubstrateTxFactory<Context> = useCallback(
+    (api) => {
+      return api.tx.multiAssetDelegation.executeDelegatorUnstake();
+    },
+    [],
+  );
+
+  return useAgnosticTx({
+    name: TxName.RESTAKE_DEPOSITED_UNSTAKE_EXECUTE,
+    abi: RESTAKING_PRECOMPILE_ABI,
+    precompileAddress: PrecompileAddress.RESTAKING,
+    evmTxFactory,
+    substrateTxFactory,
+    successMessageByTxName: SUCCESS_MESSAGES,
+  });
+};
+
+export default useDepositedRestakeUnstakeExecuteTx;

--- a/apps/tangle-dapp/src/data/restake/useDepositedRestakeUnstakeExecuteTx.ts
+++ b/apps/tangle-dapp/src/data/restake/useDepositedRestakeUnstakeExecuteTx.ts
@@ -22,12 +22,9 @@ const useDepositedRestakeUnstakeExecuteTx = () => {
     };
   }, []);
 
-  const substrateTxFactory: SubstrateTxFactory<Context> = useCallback(
-    (api) => {
-      return api.tx.multiAssetDelegation.executeDelegatorUnstake();
-    },
-    [],
-  );
+  const substrateTxFactory: SubstrateTxFactory<Context> = useCallback((api) => {
+    return api.tx.multiAssetDelegation.executeDelegatorUnstake();
+  }, []);
 
   return useAgnosticTx({
     name: TxName.RESTAKE_DEPOSITED_UNSTAKE_EXECUTE,

--- a/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
+++ b/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
@@ -17,7 +17,7 @@ const useNativeRestakeAssetBalance = (): BN | null => {
     }
 
     return delegatorInfo.delegations
-      .filter((item) => item.assetId === NATIVE_ASSET_ID)
+      .filter((item) => item.assetId === NATIVE_ASSET_ID && item.isNomination)
       .reduce(
         (acc, item) => acc.add(new BN(item.amountBonded.toString())),
         new BN(0),

--- a/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
+++ b/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
@@ -29,7 +29,9 @@ const useNativeRestakeAssetBalance = (): BN | null => {
       return null;
     }
 
-    return bondedInStaking.value.sub(delegated);
+    const nominatedBalance = bondedInStaking.value.sub(delegated);
+    
+    return nominatedBalance.isNeg() ? BN_ZERO : nominatedBalance;
   }, [bondedInStaking, delegated]);
 
   return balance;

--- a/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
+++ b/apps/tangle-dapp/src/data/restake/useNativeRestakeAssetBalance.ts
@@ -30,7 +30,7 @@ const useNativeRestakeAssetBalance = (): BN | null => {
     }
 
     const nominatedBalance = bondedInStaking.value.sub(delegated);
-    
+
     return nominatedBalance.isNeg() ? BN_ZERO : nominatedBalance;
   }, [bondedInStaking, delegated]);
 

--- a/apps/tangle-dapp/src/hooks/useTxNotification.tsx
+++ b/apps/tangle-dapp/src/hooks/useTxNotification.tsx
@@ -46,6 +46,7 @@ export const SUCCESS_MESSAGES: Record<TxName, string> = {
   [TxName.RESTAKE_NATIVE_DELEGATE]: 'Restaked native tokens',
   [TxName.RESTAKE_NATIVE_UNSTAKE]: 'Scheduled undelegate request',
   [TxName.RESTAKE_NATIVE_UNSTAKE_EXECUTE]: 'Undelegate request(s) executed',
+  [TxName.RESTAKE_DEPOSITED_UNSTAKE_EXECUTE]: 'Undelegate request(s) executed',
   [TxName.RESTAKE_NATIVE_UNSTAKE_CANCEL]: 'Undelegate request(s) cancelled',
 };
 

--- a/apps/tangle-dapp/src/pages/restake/delegate/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/delegate/index.tsx
@@ -202,7 +202,7 @@ const RestakeDelegateForm: FC<Props> = ({ assets }) => {
         const balance = new BN((amount - delegatedAmount).toString());
         const asset = assets?.get(assetId);
 
-        if (asset === undefined) {
+        if (asset === undefined || balance.isZero()) {
           return [];
         }
 

--- a/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
@@ -128,8 +128,16 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
 
   const calculateUndelegatableAmount = useCallback(
     (
-      delegation: { operatorAccountId: string; assetId: string; amountBonded: bigint },
-      unstakeRequests: { operatorAccountId: string; assetId: string; amount: bigint }[],
+      delegation: {
+        operatorAccountId: string;
+        assetId: string;
+        amountBonded: bigint;
+      },
+      unstakeRequests: {
+        operatorAccountId: string;
+        assetId: string;
+        amount: bigint;
+      }[],
     ) => {
       const pendingUnstakeAmount = unstakeRequests
         .filter(
@@ -243,8 +251,6 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
     assets !== null &&
     executeNativeUnstakeTx !== null;
 
-
-
   const onSubmit = useCallback<SubmitHandler<UnstakeFormFields>>(
     async ({ amount, assetId, operatorAccountId }) => {
       const asset = assets?.get(assetId);
@@ -281,7 +287,14 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
       });
       setIsSelectedNomination(false);
     },
-    [assets, executeNativeUnstakeTx, isReady, restakeApi, setFormValue, isSelectedNomination],
+    [
+      assets,
+      executeNativeUnstakeTx,
+      isReady,
+      restakeApi,
+      setFormValue,
+      isSelectedNomination,
+    ],
   );
 
   return (

--- a/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
@@ -3,8 +3,7 @@ import { Cross1Icon } from '@radix-ui/react-icons';
 import { ZERO_BIG_INT } from '@tangle-network/dapp-config/constants';
 import { calculateTypedChainId } from '@tangle-network/dapp-types/TypedChainId';
 import isDefined from '@tangle-network/dapp-types/utils/isDefined';
-import LockFillIcon from '@tangle-network/icons/LockFillIcon';
-import { LockLineIcon } from '@tangle-network/icons/LockLineIcon';
+import { LockUnlockLineIcon } from '@tangle-network/icons/LockUnlockLineIcon';
 import useRestakeDelegatorInfo from '@tangle-network/tangle-shared-ui/data/restake/useRestakeDelegatorInfo';
 import { DelegatorUnstakeRequest } from '@tangle-network/tangle-shared-ui/types/restake';
 import { IdentityType } from '@tangle-network/tangle-shared-ui/utils/polkadot/identity';
@@ -364,12 +363,12 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
                       : {})}
                   />
                   <TransactionInputCard.MaxAmountButton
-                    maxAmount={totalDelegatedAmount ?? formattedMaxAmount}
-                    tooltipBody="Total Delegated"
+                    maxAmount={formattedMaxAmount ?? totalDelegatedAmount}
+                    tooltipBody="Available to Undelegate"
                     Icon={
                       useRef({
-                        enabled: <LockLineIcon />,
-                        disabled: <LockFillIcon />,
+                        enabled: <LockUnlockLineIcon />,
+                        disabled: <LockUnlockLineIcon />,
                       }).current
                     }
                     onClick={() => {
@@ -388,20 +387,29 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
                     useRef({
                       placeholder: <AssetPlaceholder />,
                       isDisabled: true,
-                      ...(selectedAsset && totalDelegatedAmount !== undefined
+                      ...(selectedAsset && totalDelegatedAmount !== undefined && formattedMaxAmount !== undefined
                         ? {
                             renderBody: () => (
                               <div className="flex items-center gap-2">
                                 <Typography variant="h5" fw="bold">
                                   {selectedAsset.metadata.symbol}
                                 </Typography>
-                                <Typography
-                                  variant="body2"
-                                  className="text-mono-120 dark:text-mono-100"
-                                >
-                                  Balance: {totalDelegatedAmount}{' '}
-                                  {selectedAsset.metadata.symbol}
-                                </Typography>
+                                <div className="flex flex-col gap-1">
+                                  <Typography
+                                    variant="body2"
+                                    className="text-mono-120 dark:text-mono-100"
+                                  >
+                                    Total: {totalDelegatedAmount}{' '}
+                                    {selectedAsset.metadata.symbol}
+                                  </Typography>
+                                  <Typography
+                                    variant="body2"
+                                    className="text-mono-120 dark:text-mono-100"
+                                  >
+                                    Available: {formattedMaxAmount}{' '}
+                                    {selectedAsset.metadata.symbol}
+                                  </Typography>
+                                </div>
                               </div>
                             ),
                           }

--- a/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
+++ b/apps/tangle-dapp/src/pages/restake/unstake/index.tsx
@@ -155,73 +155,75 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
     [],
   );
 
-  const { maxAmount, formattedMaxAmount, totalDelegatedAmount } = useMemo(() => {
-    if (!Array.isArray(delegatorInfo?.delegations) || assets === null) {
-      return { 
-        maxAmount: undefined, 
-        formattedMaxAmount: undefined,
-        totalDelegatedAmount: undefined 
+  const { maxAmount, formattedMaxAmount, totalDelegatedAmount } =
+    useMemo(() => {
+      if (!Array.isArray(delegatorInfo?.delegations) || assets === null) {
+        return {
+          maxAmount: undefined,
+          formattedMaxAmount: undefined,
+          totalDelegatedAmount: undefined,
+        };
+      }
+
+      const selectedDelegation = delegatorInfo.delegations.find(
+        (item) =>
+          item.assetId === selectedAssetId &&
+          item.operatorAccountId === selectedOperatorAccountId &&
+          item.isNomination === isSelectedNomination,
+      );
+
+      if (selectedDelegation === undefined) {
+        return {
+          maxAmount: undefined,
+          formattedMaxAmount: undefined,
+          totalDelegatedAmount: undefined,
+        };
+      }
+
+      const selectedDelegationAsset = assets.get(selectedDelegation.assetId);
+
+      if (selectedDelegationAsset === undefined) {
+        return {
+          maxAmount: undefined,
+          formattedMaxAmount: undefined,
+          totalDelegatedAmount: undefined,
+        };
+      }
+
+      const undelegatableAmount = calculateUndelegatableAmount(
+        selectedDelegation,
+        delegatorInfo.unstakeRequests || [],
+      );
+
+      const maxAmountBigInt = undelegatableAmount;
+
+      const formattedMaxAmount = Number(
+        formatUnits(maxAmountBigInt, selectedDelegationAsset.metadata.decimals),
+      );
+
+      const totalDelegatedBigInt = selectedDelegation.amountBonded;
+
+      const formattedTotalDelegated = Number(
+        formatUnits(
+          totalDelegatedBigInt,
+          selectedDelegationAsset.metadata.decimals,
+        ),
+      );
+
+      return {
+        maxAmount: maxAmountBigInt,
+        formattedMaxAmount,
+        totalDelegatedAmount: formattedTotalDelegated,
       };
-    }
-
-    const selectedDelegation = delegatorInfo.delegations.find(
-      (item) =>
-        item.assetId === selectedAssetId &&
-        item.operatorAccountId === selectedOperatorAccountId &&
-        item.isNomination === isSelectedNomination,
-    );
-
-    if (selectedDelegation === undefined) {
-      return { 
-        maxAmount: undefined, 
-        formattedMaxAmount: undefined,
-        totalDelegatedAmount: undefined 
-      };
-    }
-
-    const selectedDelegationAsset = assets.get(selectedDelegation.assetId);
-
-    if (selectedDelegationAsset === undefined) {
-      return { 
-        maxAmount: undefined, 
-        formattedMaxAmount: undefined,
-        totalDelegatedAmount: undefined 
-      };
-    }
-
-    const undelegatableAmount = calculateUndelegatableAmount(
-      selectedDelegation,
-      delegatorInfo.unstakeRequests || [],
-    );
-
-    const maxAmountBigInt = undelegatableAmount;
-
-    const formattedMaxAmount = Number(
-      formatUnits(maxAmountBigInt, selectedDelegationAsset.metadata.decimals),
-    );
-
-    const totalDelegatedBigInt = selectedDelegation.amountBonded;
-    
-    const formattedTotalDelegated = Number(
-      formatUnits(totalDelegatedBigInt, selectedDelegationAsset.metadata.decimals),
-    );
-
-
-
-    return {
-      maxAmount: maxAmountBigInt,
-      formattedMaxAmount,
-      totalDelegatedAmount: formattedTotalDelegated,
-    };
-  }, [
-    delegatorInfo?.delegations,
-    delegatorInfo?.unstakeRequests,
-    assets,
-    selectedAssetId,
-    selectedOperatorAccountId,
-    isSelectedNomination,
-    calculateUndelegatableAmount,
-  ]);
+    }, [
+      delegatorInfo?.delegations,
+      delegatorInfo?.unstakeRequests,
+      assets,
+      selectedAssetId,
+      selectedOperatorAccountId,
+      isSelectedNomination,
+      calculateUndelegatableAmount,
+    ]);
 
   const customAmountProps = useMemo<TextFieldInputProps>(() => {
     const step = decimalsToStep(selectedAsset?.metadata.decimals);
@@ -287,8 +289,6 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
       if (!(amountBn instanceof BN)) {
         return;
       }
-
-
 
       if (assetId === NATIVE_ASSET_ID) {
         if (isSelectedNomination) {
@@ -387,7 +387,9 @@ const RestakeUnstakeForm: FC<RestakeUnstakeFormProps> = ({ assets }) => {
                     useRef({
                       placeholder: <AssetPlaceholder />,
                       isDisabled: true,
-                      ...(selectedAsset && totalDelegatedAmount !== undefined && formattedMaxAmount !== undefined
+                      ...(selectedAsset &&
+                      totalDelegatedAmount !== undefined &&
+                      formattedMaxAmount !== undefined
                         ? {
                             renderBody: () => (
                               <div className="flex items-center gap-2">

--- a/apps/tangle-dapp/src/utils/getAssetLabelColorClasses.ts
+++ b/apps/tangle-dapp/src/utils/getAssetLabelColorClasses.ts
@@ -1,0 +1,23 @@
+/**
+ * Get Tailwind CSS classes for asset label colors based on the label color type.
+ */
+export const getAssetLabelColorClasses = (
+  labelColor: 'green' | 'purple' | 'blue' | 'red' | 'yellow',
+): string => {
+  switch (labelColor) {
+    case 'green':
+      return 'bg-green-100 text-mono-0 dark:bg-green-900 dark:text-mono-0';
+    case 'purple':
+      return 'bg-purple-900 text-mono-0 dark:bg-purple-900 dark:text-mono-0';
+    case 'blue':
+      return 'bg-blue-900 text-mono-0 dark:bg-blue-900 dark:text-mono-0';
+    case 'red':
+      return 'bg-red-900 text-mono-0 dark:bg-red-900 dark:text-mono-0';
+    case 'yellow':
+      return 'bg-yellow-900 text-mono-0 dark:bg-yellow-900 dark:text-mono-0';
+    default:
+      return 'bg-blue-900 text-mono-0 dark:bg-blue-900 dark:text-mono-0';
+  }
+};
+
+export default getAssetLabelColorClasses;

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeDelegatorInfo.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeDelegatorInfo.ts
@@ -63,6 +63,7 @@ export default function useRestakeDelegatorInfo() {
                 operatorAccountId: assertSubstrateAddress(
                   delegation.operator.toString(),
                 ),
+                isNomination: delegation.isNomination.toHuman() as boolean,
               };
             });
 

--- a/libs/tangle-shared-ui/src/data/restake/useRestakeDelegatorInfo.ts
+++ b/libs/tangle-shared-ui/src/data/restake/useRestakeDelegatorInfo.ts
@@ -108,6 +108,7 @@ function getUnstakeRequests(
       assetId: createRestakeAssetId(req.asset),
       requestedRound: req.requestedRound.toNumber(),
       operatorAccountId: assertSubstrateAddress(req.operator.toString()),
+      isNomination: req.isNomination.toHuman() as boolean,
     } satisfies DelegatorInfo['unstakeRequests'][number];
   });
 }

--- a/libs/tangle-shared-ui/src/types/restake.ts
+++ b/libs/tangle-shared-ui/src/types/restake.ts
@@ -91,6 +91,7 @@ export type DelegatorUnstakeRequest = {
   readonly assetId: RestakeAssetId;
   readonly amount: bigint;
   readonly requestedRound: number;
+  readonly isNomination: boolean;
 };
 
 /**

--- a/libs/tangle-shared-ui/src/types/restake.ts
+++ b/libs/tangle-shared-ui/src/types/restake.ts
@@ -83,6 +83,7 @@ export type DelegatorBondInfo = {
   readonly operatorAccountId: SubstrateAddress;
   readonly amountBonded: bigint;
   readonly assetId: RestakeAssetId;
+  readonly isNomination: boolean;
 };
 
 export type DelegatorUnstakeRequest = {


### PR DESCRIPTION
## Summary of changes

- Fixes restake flow bugs and adds minor UI improvements.

Note 📝

- This PR focuses on fixing bugs related to the logic for calling the `multiAssetDelegation` pallet extrinsics and on testing that all the restake flows work as intended.
- Loading states and notifications in certain flows are buggy and will be addressed in a separate PR, along with general UX improvements.

### Proposed area of change

- [x] `apps/tangle-dapp`
- [ ] `apps/tangle-cloud`
- [ ] `apps/leaderboard`
- [x] `libs/tangle-shared-ui`
- [ ] `libs/ui-components`

### Screen Recording

**_Restake Flow 1 (Deposit)_**

https://github.com/user-attachments/assets/a698a1ba-3916-406f-ae85-6dbe70c61b2e

**_Restake Flow 2 (Nomination)_**

https://github.com/user-attachments/assets/dcc11163-344a-4b8d-8e1f-bab4fe1d284d